### PR TITLE
Introduce runtime run/round state, scoring, quota and trinket systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,22 @@ If you want to refine further, the next big balance levers to define are:
 - How many playable hands per round?
 - Does that number scale?
 - Do rerolls ever increase via trinkets?
+
+## Foundation Defaults (Implemented)
+
+To lock in a strong foundation, the project now has explicit runtime state and balance defaults:
+
+- **Run state** tracks current round and persistent trinkets.
+- **Round state** tracks quota, hands remaining, and rerolls remaining.
+- **Hand scoring table** provides base and additive multiplier values per hand type.
+- **Score calculator** applies:
+  - `Hand Base = HandType_Base + Sum(Scoring Dice Faces) + Trinket Base Bonuses`
+  - `Total Mult = 1 + HandType_Mult + Trinket Mult Bonuses`
+  - `Final Score = Hand Base × Total Mult`
+- **Quota scaling** defaults to exponential growth:
+  - `Quota_n = 100 × 1.45^(Round-1)`
+- **Hands per round** currently scale slowly:
+  - Base 4 hands, +1 hand every 3 rounds.
+- **Rerolls** default to 3 per round, with optional trinket-based increases.
+
+These defaults are intentionally centralized so they can be tuned without rewriting gameplay flow.

--- a/autoload/event_bus.gd
+++ b/autoload/event_bus.gd
@@ -7,3 +7,24 @@ signal roll_all_dice_requested
 
 # Emitted after hand evaluation is complete.
 signal dice_evaluated(result: HandResult)
+
+# Emitted when a run is initialized.
+signal run_started(round_state: RoundStateModel)
+
+# Emitted when a new round starts.
+signal round_started(round_state: RoundStateModel)
+
+# Emitted whenever hands/rerolls/quota values change.
+signal round_state_changed(round_state: RoundStateModel)
+
+# Emitted after a scored hand is submitted.
+signal hand_scored(score: int, quota_remaining: int)
+
+# Emitted when player clears the current quota.
+signal round_cleared(round_state: RoundStateModel)
+
+# Emitted when no playable hands remain and quota is still positive.
+signal run_failed(round_state: RoundStateModel)
+
+# Emitted when a trinket is added to the run.
+signal trinket_added(trinket: TrinketModel)

--- a/autoload/game_session_service.gd
+++ b/autoload/game_session_service.gd
@@ -1,0 +1,53 @@
+extends Node
+
+# NOTE: Central run/round orchestrator for quota, hands, and reroll budgets.
+var run_state := RunStateModel.new()
+var round_state := RoundStateModel.new()
+
+func _ready() -> void:
+	start_new_run()
+
+func start_new_run() -> void:
+	run_state.start_new_run()
+	_start_round(run_state.round_index)
+	EventBus.run_started.emit(round_state)
+
+func _start_round(round_index: int) -> void:
+	var quota := QuotaService.get_quota_for_round(round_index)
+	var hands := GameBalanceConfig.get_hands_for_round(round_index)
+	var rerolls := GameBalanceConfig.BASE_REROLLS_PER_ROUND + run_state.get_extra_rerolls()
+	round_state.configure(round_index, quota, hands, rerolls)
+	EventBus.round_started.emit(round_state)
+	EventBus.round_state_changed.emit(round_state)
+
+func can_use_reroll() -> bool:
+	return round_state.can_reroll()
+
+func spend_reroll() -> bool:
+	var spent := round_state.spend_reroll()
+	if spent:
+		EventBus.round_state_changed.emit(round_state)
+	return spent
+
+func submit_hand(result: HandResult, values: Array[int]) -> int:
+	if not round_state.consume_hand():
+		return 0
+
+	var score := ScoreCalculatorService.calculate(result, values, run_state)
+	round_state.apply_score(score)
+	EventBus.hand_scored.emit(score, round_state.current_quota)
+	EventBus.round_state_changed.emit(round_state)
+
+	if round_state.is_cleared():
+		EventBus.round_cleared.emit(round_state)
+		run_state.advance_round()
+		_start_round(run_state.round_index)
+	elif round_state.is_failed():
+		run_state.end_run()
+		EventBus.run_failed.emit(round_state)
+
+	return score
+
+func add_trinket(trinket: TrinketModel) -> void:
+	run_state.add_trinket(trinket)
+	EventBus.trinket_added.emit(trinket)

--- a/core/models/game_balance_config.gd
+++ b/core/models/game_balance_config.gd
@@ -1,0 +1,15 @@
+class_name GameBalanceConfig
+
+# NOTE: Explicit balance levers captured from README TODOs.
+const BASE_QUOTA: int = 100
+const QUOTA_GROWTH_RATE: float = 1.45
+
+const BASE_HANDS_PER_ROUND: int = 4
+const HANDS_GAIN_EVERY_N_ROUNDS: int = 3
+
+const BASE_REROLLS_PER_ROUND: int = 3
+
+static func get_hands_for_round(round_index: int) -> int:
+	var normalized_round := max(1, round_index)
+	var bonus_hands := int((normalized_round - 1) / HANDS_GAIN_EVERY_N_ROUNDS)
+	return BASE_HANDS_PER_ROUND + bonus_hands

--- a/core/models/hand_scoring_table.gd
+++ b/core/models/hand_scoring_table.gd
@@ -1,0 +1,35 @@
+class_name HandScoringTable
+
+# NOTE: Foundation values that can later be moved to external resources.
+# The keys are HandEvaluatorModel.HandType values.
+const BASE_BY_TYPE := {
+	HandEvaluatorModel.HandType.HIGH_DIE: 2,
+	HandEvaluatorModel.HandType.ONE_PAIR: 5,
+	HandEvaluatorModel.HandType.TWO_PAIR: 9,
+	HandEvaluatorModel.HandType.THREE_OF_A_KIND: 13,
+	HandEvaluatorModel.HandType.STRAIGHT: 20,
+	HandEvaluatorModel.HandType.FULL_HOUSE: 24,
+	HandEvaluatorModel.HandType.FOUR_OF_A_KIND: 30,
+	HandEvaluatorModel.HandType.FIVE_OF_A_KIND: 45
+}
+
+const MULT_BY_TYPE := {
+	HandEvaluatorModel.HandType.HIGH_DIE: 0.0,
+	HandEvaluatorModel.HandType.ONE_PAIR: 0.1,
+	HandEvaluatorModel.HandType.TWO_PAIR: 0.25,
+	HandEvaluatorModel.HandType.THREE_OF_A_KIND: 0.5,
+	HandEvaluatorModel.HandType.STRAIGHT: 0.8,
+	HandEvaluatorModel.HandType.FULL_HOUSE: 1.0,
+	HandEvaluatorModel.HandType.FOUR_OF_A_KIND: 1.5,
+	HandEvaluatorModel.HandType.FIVE_OF_A_KIND: 2.5
+}
+
+static func get_base(hand_type: int) -> int:
+	if not BASE_BY_TYPE.has(hand_type):
+		return 0
+	return BASE_BY_TYPE[hand_type]
+
+static func get_mult(hand_type: int) -> float:
+	if not MULT_BY_TYPE.has(hand_type):
+		return 0.0
+	return MULT_BY_TYPE[hand_type]

--- a/core/models/round_state_model.gd
+++ b/core/models/round_state_model.gd
@@ -1,0 +1,50 @@
+class_name RoundStateModel
+
+# NOTE: Runtime state for a single round.
+var round_index: int = 1
+var starting_quota: int = 0
+var current_quota: int = 0
+
+var hands_total: int = 0
+var hands_remaining: int = 0
+
+var rerolls_total: int = 0
+var rerolls_remaining: int = 0
+
+func configure(p_round_index: int, p_quota: int, p_hands: int, p_rerolls: int) -> void:
+	round_index = max(1, p_round_index)
+	starting_quota = max(0, p_quota)
+	current_quota = starting_quota
+
+	hands_total = max(0, p_hands)
+	hands_remaining = hands_total
+
+	rerolls_total = max(0, p_rerolls)
+	rerolls_remaining = rerolls_total
+
+func can_play_hand() -> bool:
+	return hands_remaining > 0 and current_quota > 0
+
+func can_reroll() -> bool:
+	return rerolls_remaining > 0
+
+func spend_reroll() -> bool:
+	if rerolls_remaining <= 0:
+		return false
+	rerolls_remaining -= 1
+	return true
+
+func consume_hand() -> bool:
+	if hands_remaining <= 0:
+		return false
+	hands_remaining -= 1
+	return true
+
+func apply_score(score: int) -> void:
+	current_quota = max(0, current_quota - max(0, score))
+
+func is_cleared() -> bool:
+	return current_quota <= 0
+
+func is_failed() -> bool:
+	return hands_remaining <= 0 and current_quota > 0

--- a/core/models/run_state_model.gd
+++ b/core/models/run_state_model.gd
@@ -1,0 +1,38 @@
+class_name RunStateModel
+
+# NOTE: Persisted state for the full run session.
+var round_index: int = 1
+var trinkets: Array[TrinketModel] = []
+var is_active: bool = false
+
+func start_new_run() -> void:
+	round_index = 1
+	trinkets.clear()
+	is_active = true
+
+func advance_round() -> void:
+	round_index += 1
+
+func end_run() -> void:
+	is_active = false
+
+func add_trinket(trinket: TrinketModel) -> void:
+	trinkets.append(trinket)
+
+func get_total_multiplier_bonus() -> float:
+	var total := 0.0
+	for trinket in trinkets:
+		total += trinket.mult_bonus
+	return total
+
+func get_total_hand_base_bonus(hand_type: int) -> int:
+	var total := 0
+	for trinket in trinkets:
+		total += trinket.get_base_bonus_for(hand_type)
+	return total
+
+func get_extra_rerolls() -> int:
+	var total := 0
+	for trinket in trinkets:
+		total += trinket.extra_round_rerolls
+	return total

--- a/core/models/trinket_model.gd
+++ b/core/models/trinket_model.gd
@@ -1,0 +1,32 @@
+class_name TrinketModel
+
+# NOTE: Lightweight runtime trinket representation.
+var id: String = ""
+var display_name: String = ""
+
+# NOTE: Added into total multiplier as additive bonus.
+var mult_bonus: float = 0.0
+
+# NOTE: Round-level reroll extension.
+var extra_round_rerolls: int = 0
+
+# NOTE: Optional hand-specific base bonuses keyed by HandEvaluatorModel.HandType.
+var base_bonus_by_hand_type: Dictionary = {}
+
+func _init(
+	p_id: String = "",
+	p_name: String = "",
+	p_mult_bonus: float = 0.0,
+	p_extra_round_rerolls: int = 0,
+	p_base_bonus_by_hand_type: Dictionary = {}
+) -> void:
+	id = p_id
+	display_name = p_name
+	mult_bonus = p_mult_bonus
+	extra_round_rerolls = p_extra_round_rerolls
+	base_bonus_by_hand_type = p_base_bonus_by_hand_type.duplicate()
+
+func get_base_bonus_for(hand_type: int) -> int:
+	if not base_bonus_by_hand_type.has(hand_type):
+		return 0
+	return int(base_bonus_by_hand_type[hand_type])

--- a/core/services/quota_service.gd
+++ b/core/services/quota_service.gd
@@ -1,0 +1,6 @@
+class_name QuotaService
+
+static func get_quota_for_round(round_index: int) -> int:
+	var normalized_round := max(1, round_index)
+	var quota := float(GameBalanceConfig.BASE_QUOTA) * pow(GameBalanceConfig.QUOTA_GROWTH_RATE, normalized_round - 1)
+	return int(round(quota))

--- a/core/services/score_calculator_service.gd
+++ b/core/services/score_calculator_service.gd
@@ -1,0 +1,22 @@
+class_name ScoreCalculatorService
+
+static func calculate(result: HandResult, values: Array[int], run_state: RunStateModel) -> int:
+	if result == null or result.type == HandEvaluatorModel.HandType.INVALID:
+		return 0
+
+	var hand_base := HandScoringTable.get_base(result.type)
+	hand_base += _sum_scoring_dice(values, result.scoring_indices)
+	hand_base += run_state.get_total_hand_base_bonus(result.type)
+
+	var total_mult := 1.0
+	total_mult += HandScoringTable.get_mult(result.type)
+	total_mult += run_state.get_total_multiplier_bonus()
+
+	return int(round(float(hand_base) * total_mult))
+
+static func _sum_scoring_dice(values: Array[int], scoring_indices: Array[int]) -> int:
+	var total := 0
+	for index in scoring_indices:
+		if index >= 0 and index < values.size():
+			total += values[index]
+	return total

--- a/core/services/shop_service.gd
+++ b/core/services/shop_service.gd
@@ -1,0 +1,19 @@
+class_name ShopService
+
+# NOTE: Minimal in-code trinket pool until data resources are added.
+static func get_offer_pool() -> Array[TrinketModel]:
+	return [
+		TrinketModel.new("mult_chip", "Multiplier Chip", 0.2),
+		TrinketModel.new("pair_tome", "Pair Tome", 0.0, 0, {HandEvaluatorModel.HandType.ONE_PAIR: 4}),
+		TrinketModel.new("spare_roll", "Spare Roll", 0.0, 1),
+		TrinketModel.new("straight_seal", "Straight Seal", 0.15, 0, {HandEvaluatorModel.HandType.STRAIGHT: 6})
+	]
+
+static func get_random_offers(count: int) -> Array[TrinketModel]:
+	var pool := get_offer_pool()
+	pool.shuffle()
+	var to_take := mini(max(0, count), pool.size())
+	var offers: Array[TrinketModel] = []
+	for i in range(to_take):
+		offers.append(pool[i])
+	return offers

--- a/features/dice/dice_manager.gd
+++ b/features/dice/dice_manager.gd
@@ -14,12 +14,24 @@ func _ready() -> void:
 		EventBus.roll_all_dice_requested.connect(roll_all)
 
 func roll_all() -> void:
+	# NOTE: First roll for a hand is free. Extra full rolls spend from round reroll budget.
+	if dice_set.all_rolled():
+		if not GameSessionService.spend_reroll():
+			return
 	DiceRollService.roll_all(dice_set)
 
 func evaluate() -> HandResult:
 	var result := HandEvaluatorModel.evaluate(dice_set.get_values())
 	EventBus.dice_evaluated.emit(result)
 	return result
+
+func evaluate_and_submit() -> int:
+	var result := evaluate()
+	if not result.is_complete:
+		return 0
+	var score := GameSessionService.submit_hand(result, dice_set.get_values())
+	dice_set.reset()
+	return score
 
 func reset_round() -> void:
 	# NOTE: Exposed for future round-state orchestration.

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://assets/sprites/icon.svg"
 
 EventBus="*uid://daxbdt73sgi6o"
 RandomService="*uid://c0fgr7t8bd3b7"
+GameSessionService="*res://autoload/game_session_service.gd"
 
 [physics]
 

--- a/ui/hud/hud_view.gd
+++ b/ui/hud/hud_view.gd
@@ -4,6 +4,10 @@ func _ready() -> void:
 	# NOTE: Listen globally for evaluation results.
 	if EventBus.dice_evaluated.is_connected(show_result) == false:
 		EventBus.dice_evaluated.connect(show_result)
+	if EventBus.round_state_changed.is_connected(show_round_state) == false:
+		EventBus.round_state_changed.connect(show_round_state)
+	if EventBus.hand_scored.is_connected(show_score) == false:
+		EventBus.hand_scored.connect(show_score)
 
 func show_result(result: HandResult) -> void:
 	# NOTE: Include note for debugging and future score breakdown UI.
@@ -13,3 +17,14 @@ func show_result(result: HandResult) -> void:
 		# NOTE: Hook for die highlight animations in the HUD layer.
 		# highlight_die(index)
 		pass
+
+func show_round_state(round_state: RoundStateModel) -> void:
+	$Label.text = "Round %d | Quota %d | Hands %d | Rerolls %d" % [
+		round_state.round_index,
+		round_state.current_quota,
+		round_state.hands_remaining,
+		round_state.rerolls_remaining
+	]
+
+func show_score(score: int, quota_remaining: int) -> void:
+	$Label.text = "Scored %d | Quota Left %d" % [score, quota_remaining]


### PR DESCRIPTION
### Motivation

- Centralize and lock in foundational gameplay defaults for quota growth, hands per round and rerolls so tuning is possible without changing flow. 
- Provide explicit runtime state for runs and rounds and add support for persistent trinkets to enable additive bonuses and reroll extensions. 
- Implement a deterministic score calculation and quota scaling system to make scoring and failure conditions explicit. 

### Description

- Add runtime models: `RunStateModel`, `RoundStateModel`, `TrinketModel`, and `HandScoringTable` to represent run/round state, trinkets and base scoring values. 
- Add balance/config and service layers: `GameBalanceConfig`, `QuotaService`, `ScoreCalculatorService`, and `ShopService` to centralize defaults, quota growth, score computation and a minimal trinket pool. 
- Add `GameSessionService` orchestrator and expand `EventBus` signals to drive run/round lifecycle, scoring, trinket events and failure/clear notifications, and register the service in `project.godot` autoloads. 
- Integrate session logic into gameplay code by updating `dice_manager.gd` to spend full-roll rerolls and submit scored hands, and update `hud_view.gd` to display round state and score feedback. 
- Update `README.md` with the implemented foundation defaults and a brief explanation of the scoring and quota mechanics. 

### Testing

- No automated tests were added or executed as part of this change; existing automated test coverage was not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a584dc808331b7fe2f8dcf46e692)