### PR TITLE
Populate die scene nodes with their scripts

### DIFF
--- a/features/dice/die/die.tscn
+++ b/features/dice/die/die.tscn
@@ -1,8 +1,11 @@
 [gd_scene format=3 uid="uid://biptkm4ujpe6i"]
 
 [ext_resource type="Texture2D" uid="uid://cwpdpecr61tj2" path="res://assets/sprites/dice/1-6 Pip Style 1 (SpriteSheet).png" id="1_clpct"]
+[ext_resource type="Script" path="res://features/dice/die/die_controller.gd" id="2_b7hop"]
+[ext_resource type="Script" path="res://features/dice/die/die_view.gd" id="3_jpvqg"]
 
 [node name="Die" type="Control" unique_id=644122590]
+script = ExtResource("2_b7hop")
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 3
 anchors_preset = 0
@@ -10,6 +13,7 @@ offset_right = 18.0
 offset_bottom = 18.0
 
 [node name="FaceSprite" type="Sprite2D" parent="." unique_id=788261950]
+script = ExtResource("3_jpvqg")
 texture_filter = 1
 position = Vector2(40, 40)
 scale = Vector2(5, 5)

--- a/features/dice/die/die_controller.gd
+++ b/features/dice/die/die_controller.gd
@@ -7,7 +7,7 @@ func bind(die_model: DieModel) -> void:
 	model = die_model
 
 func _ready() -> void:
-	$Button.pressed.connect(_on_pressed)
+	$HoldButton.pressed.connect(_on_pressed)
 
 func _on_pressed() -> void:
 	# NOTE: Direct die roll for now. In future this should route through


### PR DESCRIPTION
### Motivation
- Ensure the die scene is fully wired so runtime nodes have their corresponding scripts and signal hookups to avoid broken node paths and make dice behavior driveable from the scene file.

### Description
- Add `die_controller.gd` and `die_view.gd` as `ext_resource`s in `features/dice/die/die.tscn` so scripts are referenced directly from the scene file.
- Attach `die_controller.gd` to the root `Die` node by setting `script = ExtResource("2_b7hop")` in `features/dice/die/die.tscn`.
- Attach `die_view.gd` to the `FaceSprite` node by setting `script = ExtResource("3_jpvqg")` in `features/dice/die/die.tscn`.
- Fix the controller signal hookup to use the correct node path by changing `$Button.pressed.connect(_on_pressed)` to `$HoldButton.pressed.connect(_on_pressed)` in `features/dice/die/die_controller.gd`.

### Testing
- No automated test suite was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bd2bc2a483318a0ef741c18e81e4)