### PR TITLE
Add die hold toggle and lerped hold-lift animation

### DIFF
--- a/core/models/die_model.gd
+++ b/core/models/die_model.gd
@@ -1,9 +1,11 @@
 class_name DieModel
 
 signal value_changed(new_value: int)
+signal hold_changed(is_held: bool)
 
 var faces: Array[int]
 var current_index: int = -1
+var held: bool = false
 
 func _init(face_values: Array[int]) -> void:
 	# NOTE: A die without faces can never roll. We keep the array empty,
@@ -26,6 +28,18 @@ func get_value() -> int:
 func get_face_count() -> int:
 	return faces.size()
 
+func set_held(next_held: bool) -> void:
+	if held == next_held:
+		return
+	held = next_held
+	hold_changed.emit(held)
+
+func toggle_hold() -> void:
+	set_held(not held)
+
+func is_held() -> bool:
+	return held
+
 func has_value() -> bool:
 	# NOTE: `true` means the die has been rolled at least once this round.
 	return current_index != -1
@@ -33,4 +47,5 @@ func has_value() -> bool:
 func reset() -> void:
 	# NOTE: Round reset clears the roll state and notifies listeners.
 	current_index = -1
+	set_held(false)
 	value_changed.emit(0)

--- a/core/services/dice_roll_service.gd
+++ b/core/services/dice_roll_service.gd
@@ -9,7 +9,9 @@ static func roll_die(die: DieModel) -> void:
 	var index := RandomService.randi_range(0, max_index)
 	die.roll_to(index)
 
-# NOTE: Rolls all dice in a set.
+# NOTE: Rolls all non-held dice in a set.
 static func roll_all(dice_set: DiceSetModel) -> void:
 	for die in dice_set.dice:
+		if die.is_held():
+			continue
 		roll_die(die)

--- a/features/dice/dice_manager.gd
+++ b/features/dice/dice_manager.gd
@@ -9,9 +9,24 @@ func _ready() -> void:
 		var die: DieModel = DieModel.new([1, 2, 3, 4, 5, 6])
 		dice_set.add_die(die)
 
+	_bind_die_nodes()
+
 	# NOTE: EventBus integration keeps UI/input systems decoupled from dice logic.
 	if EventBus.roll_all_dice_requested.is_connected(roll_all) == false:
 		EventBus.roll_all_dice_requested.connect(roll_all)
+
+func _bind_die_nodes() -> void:
+	var die_nodes: Array[Node] = $HBoxContainer.get_children()
+	var limit: int = mini(die_nodes.size(), dice_set.dice.size())
+	for index in limit:
+		var die_node: Node = die_nodes[index]
+		var die_model: DieModel = dice_set.dice[index]
+		if die_node.has_method("bind"):
+			die_node.bind(die_model)
+		if die_node.has_node("FaceSprite"):
+			var face_sprite: Node = die_node.get_node("FaceSprite")
+			if face_sprite.has_method("bind"):
+				face_sprite.bind(die_model)
 
 func roll_all() -> void:
 	# NOTE: First roll for a hand is free. Extra full rolls spend from round reroll budget.

--- a/features/dice/die/die_controller.gd
+++ b/features/dice/die/die_controller.gd
@@ -10,8 +10,6 @@ func _ready() -> void:
 	$HoldButton.pressed.connect(_on_pressed)
 
 func _on_pressed() -> void:
-	# NOTE: Direct die roll for now. In future this should route through
-	# turn-state checks to prevent rolling at invalid times.
 	if model == null:
 		return
-	DiceRollService.roll_die(model)
+	model.toggle_hold()

--- a/features/dice/die/die_view.gd
+++ b/features/dice/die/die_view.gd
@@ -1,12 +1,37 @@
 extends Sprite2D
 
+const HOLD_LIFT_Y: float = -80.0
+const HOLD_LERP_SPEED: float = 10.0
+
 # NOTE: Pure visual binding for one die model.
 var model: DieModel
+var base_position: Vector2
+var hold_target_position: Vector2
+
+func _ready() -> void:
+	base_position = position
+	hold_target_position = base_position + Vector2(0.0, HOLD_LIFT_Y)
+
+func _process(delta: float) -> void:
+	if model == null:
+		return
+	var target: Vector2 = base_position
+	if model.is_held():
+		target = hold_target_position
+	position = position.lerp(target, delta * HOLD_LERP_SPEED)
 
 func bind(die_model: DieModel) -> void:
 	model = die_model
 	model.value_changed.connect(_on_value_changed)
+	model.hold_changed.connect(_on_hold_changed)
+	_on_hold_changed(model.is_held())
 
 func _on_value_changed(value: int) -> void:
 	# Convention: 0 means "unrolled" visual state.
 	frame = value - 1
+
+func _on_hold_changed(is_held: bool) -> void:
+	if is_held:
+		z_index = 1
+	else:
+		z_index = 0


### PR DESCRIPTION
### Motivation
- Make the die "Hold" button toggle a held state instead of immediately rolling the die so players can hold dice between rolls. 
- Visually indicate held dice by lifting them so the UI clearly communicates held state. 
- Ensure held dice are preserved during full rerolls so game logic respects the hold state.

### Description
- Added a `held` state, `hold_changed` signal, and helper methods `set_held`, `toggle_hold`, and `is_held` to `DieModel` and ensured the hold state is cleared on `reset` (`core/models/die_model.gd`).
- Changed die input handling so the die scene controller calls `model.toggle_hold()` when the `HoldButton` is pressed (`features/dice/die/die_controller.gd`).
- Updated `DiceRollService.roll_all` to skip dice where `die.is_held()` returns `true` so held dice retain their face (`core/services/dice_roll_service.gd`).
- Bound die scene instances to their `DieModel` counterparts in `dice_manager.gd` so both controller and view receive model events (`features/dice/dice_manager.gd`).
- Implemented a lerped hold animation in the die view that moves the die up by 80 units when held and lerps back when released, and toggles `z_index` on hold changes (`features/dice/die/die_view.gd`).

### Testing
- Ran `git diff --check`, which reported no whitespace or merge issues and succeeded. 
- Searched the codebase with `rg` for the new APIs and wiring (`toggle_hold`, `hold_changed`, `is_held`, `_bind_die_nodes`, `HOLD_LIFT_Y`) and confirmed references were present. 
- Performed local integration verification by inspecting modified files to ensure bindings and signal connections are in place (no automated unit tests were added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c352ca908331be188ebbd676216a)