### PR TITLE
Initialize typed hand_model and auto-populate pre-existing dice on ready

### DIFF
--- a/features/dice/hand.gd
+++ b/features/dice/hand.gd
@@ -3,12 +3,15 @@ extends Node
 @onready var hand_controller = $HandController
 @onready var hand_visuals = $HandVisuals
 
-var hand_model = HandModel
+var hand_model : HandModel
 
 func _ready() -> void:
+	hand_model = hand_controller.hand_model
 	hand_controller.hand_populated.connect(_on_hand_populated)
+	if hand_model.dice.size() > 0:
+		_on_hand_populated()
 
-func _on_hand_populated():
+func _on_hand_populated() -> void:
 	hand_model = hand_controller.hand_model
 	for die in hand_model.dice:
 		die.roll()


### PR DESCRIPTION
### Motivation
- Ensure `hand_model` is properly typed and initialized and to handle cases where the hand already contains dice at `_ready` so those dice get populated/rolled immediately.

### Description
- Add a type annotation `var hand_model : HandModel` and assign it from `hand_controller.hand_model` in `_ready`.
- Invoke `_on_hand_populated()` during `_ready` when `hand_model.dice.size() > 0` so pre-existing dice are rolled on startup, and add explicit `-> void` return type to `_ready` and `_on_hand_populated`.

### Testing
- Ran the project's automated test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5995b328c83319b7c333e52d60fee)