### PR TITLE
Sync die model to controller and initialize hand model on ready

### DIFF
--- a/features/dice/die/die.gd
+++ b/features/dice/die/die.gd
@@ -2,8 +2,12 @@ extends Control
 
 @onready var die_controller = $DieController
 
-var model = DieModel.new()
+var model: DieModel = DieModel.new():
+	set(value):
+		model = value
+		if is_node_ready():
+			die_controller.model = model
 
 func _ready() -> void:
-	model = die_controller.model
+	die_controller.model = model
 	

--- a/features/dice/hand.gd
+++ b/features/dice/hand.gd
@@ -3,12 +3,15 @@ extends Node
 @onready var hand_controller = $HandController
 @onready var hand_visuals = $HandVisuals
 
-var hand_model = HandModel
+var hand_model : HandModel
 
 func _ready() -> void:
+	hand_model = hand_controller.hand_model
 	hand_controller.hand_populated.connect(_on_hand_populated)
+	if hand_model.dice.size() > 0:
+		_on_hand_populated()
 
-func _on_hand_populated():
+func _on_hand_populated() -> void:
 	hand_model = hand_controller.hand_model
 	for die in hand_model.dice:
 		die.roll()


### PR DESCRIPTION
### Motivation
- Ensure model propagation between UI nodes and their controllers so controller state isn't overwritten on startup.
- Fix initialization order so existing dice in a hand are detected and populated when the scene is ready.

### Description
- Add a typed `model` property to `features/dice/die/die.gd` with a setter that updates `die_controller.model` when the node is ready. 
- Change `Die` `_ready()` to assign the controller from the die model instead of overwriting the model from the controller. 
- Add a `hand_model : HandModel` annotation in `features/dice/hand.gd` and initialize it from `hand_controller.hand_model` in `_ready()`. 
- Call `_on_hand_populated()` during `_ready()` if the hand already contains dice and ensure `_on_hand_populated()` rolls each die.

### Testing
- Ran the project's automated test suite and linter; all tests and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5995b328c83319b7c333e52d60fee)