### PR TITLE
Add model setters and safe signal (dis)connection for dice; initialize hand model on ready

### DIFF
--- a/features/dice/die/die.gd
+++ b/features/dice/die/die.gd
@@ -2,8 +2,12 @@ extends Control
 
 @onready var die_controller = $DieController
 
-var model = DieModel.new()
+var model: DieModel = DieModel.new():
+	set(value):
+		model = value
+		if is_node_ready():
+			die_controller.model = model
 
 func _ready() -> void:
-	model = die_controller.model
+	die_controller.model = model
 	

--- a/features/dice/die/die_controller.gd
+++ b/features/dice/die/die_controller.gd
@@ -3,12 +3,30 @@ extends Node
 @export var die_visuals: Node
 @export var select_button: Button
 
-var model := DieModel.new()
+var model: DieModel = DieModel.new():
+	set(value):
+		if model == value:
+			return
+		_disconnect_model_signals(model)
+		model = value
+		if is_node_ready():
+			_connect_model_signals(model)
 
 func _ready():
 	select_button.pressed.connect(_on_select_pressed)
-	model.rolled.connect(_on_dice_rolled)
-	model.die_selected.connect(_on_is_selected)
+	_connect_model_signals(model)
+
+func _connect_model_signals(target_model: DieModel) -> void:
+	if !target_model.rolled.is_connected(_on_dice_rolled):
+		target_model.rolled.connect(_on_dice_rolled)
+	if !target_model.die_selected.is_connected(_on_is_selected):
+		target_model.die_selected.connect(_on_is_selected)
+
+func _disconnect_model_signals(target_model: DieModel) -> void:
+	if target_model.rolled.is_connected(_on_dice_rolled):
+		target_model.rolled.disconnect(_on_dice_rolled)
+	if target_model.die_selected.is_connected(_on_is_selected):
+		target_model.die_selected.disconnect(_on_is_selected)
 
 func _on_select_pressed():
 	model.select()

--- a/features/dice/hand.gd
+++ b/features/dice/hand.gd
@@ -3,12 +3,15 @@ extends Node
 @onready var hand_controller = $HandController
 @onready var hand_visuals = $HandVisuals
 
-var hand_model = HandModel
+var hand_model : HandModel
 
 func _ready() -> void:
+	hand_model = hand_controller.hand_model
 	hand_controller.hand_populated.connect(_on_hand_populated)
+	if hand_model.dice.size() > 0:
+		_on_hand_populated()
 
-func _on_hand_populated():
+func _on_hand_populated() -> void:
 	hand_model = hand_controller.hand_model
 	for die in hand_model.dice:
 		die.roll()


### PR DESCRIPTION
### Motivation
- Ensure `Die` and `DieController` can have their `model` swapped safely and avoid duplicate signal connections or leaks. 
- Make controller/visual wiring robust when nodes are not yet ready by deferring assignments until `_ready`. 
- Ensure the `Hand` node initializes its `hand_model` from the controller on startup and populates existing dice immediately.

### Description
- Update `features/dice/die/die.gd` to declare `model` as a `DieModel` and add a setter that assigns the value and, when the node is ready, propagates the model to `die_controller` via `die_controller.model = model`, and set the controller model in `_ready`.
- Update `features/dice/die/die_controller.gd` to declare `model` as a `DieModel` with a setter that disconnects signals from the old model and connects signals for the new model, and add helper methods `_connect_model_signals` and `_disconnect_model_signals` to manage `rolled` and `die_selected` connections safely.
- Keep the `select_button` connection in `_ready` and use the new connect/disconnect helpers to avoid double connections when the model changes.
- Update `features/dice/hand.gd` to type `hand_model` as `HandModel`, assign it from `hand_controller.hand_model` on `_ready`, and invoke `_on_hand_populated()` immediately if there are existing dice so they are rolled/populated at startup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5995b328c83319b7c333e52d60fee)