### PR TITLE
Introduce DieInstance API, DieUI roll_if_not_selected, and README developer notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,19 @@ To lock in a strong foundation, the project now has explicit runtime state and b
 - **Rerolls** default to 3 per round, with optional trinket-based increases.
 
 These defaults are intentionally centralized so they can be tuned without rewriting gameplay flow.
+
+## Developer API Notes (Dice)
+
+To make scripting simpler while building, use this flow:
+
+1. Create a die with `DieInstance.create_standard_d6()`.
+2. Assign it to UI with `DieUI.set_die(die)`.
+3. Roll through `DieUI.roll_if_not_selected()` so hold/selection state is respected.
+
+Helpful APIs:
+- `DieInstance.configure_with_sequential_faces(face_count)`: builds an N-sided die with values `1..N`.
+- `DieInstance.set_face_values(values)`: custom face values (array size must match face count).
+- `DieInstance.roll()`: returns `FaceData` and emits `rolled(face)`.
+- `DieUI.die_rolled(face)`: UI-level signal emitted after successful rolls.
+
+This gives you a clean default path while still allowing custom dice behavior when needed.

--- a/core/node_classes/die_instance.gd
+++ b/core/node_classes/die_instance.gd
@@ -1,49 +1,76 @@
 extends Node
+## Runtime die object used by gameplay and UI.
+##
+## `DieInstance` owns a `DieData` resource (faces) and exposes convenient setup + roll APIs.
+## Use this when you need a rollable die in scene logic.
 class_name DieInstance
 
+## Emitted whenever [method roll] succeeds.
+## [param face] is the face that was rolled.
 signal rolled(face: FaceData)
 
+## Resource data for this die (all available faces).
 var data: DieData
+## Last rolled face. `null` until the first successful roll.
 var current_face: FaceData
 
 
-func make_basic_die(face_count: int) -> DieData:
+## Creates and returns a ready-to-roll 6-sided die (1..6).
+##
+## This is the easiest setup path for most scenes.
+static func create_standard_d6() -> DieInstance:
+	var die := DieInstance.new()
+	die.configure_with_sequential_faces(6)
+	return die
+
+
+## Initializes this die with [param face_count] faces and values 1..N.
+## Returns the backing [DieData] for optional advanced customization.
+func configure_with_sequential_faces(face_count: int) -> DieData:
 	data = DieData.new()
+	_initialize_faces(face_count)
 
-	set_up_die(face_count)
-
-	var face_value_array: Array[int] = []
-
+	var sequential_values: Array[int] = []
 	for i in range(face_count):
-		face_value_array.append(i + 1)  # usually dice start at 1
+		sequential_values.append(i + 1) # dice typically start from 1
 
-	apply_face_value(face_value_array)
-
+	set_face_values(sequential_values)
 	return data
 
 
-func set_up_die(face_count: int) -> DieData:
-	data.faces = []  # safer than clear()
+## Replaces each face value on the current die data.
+##
+## [param new_face_values] must match the current face count exactly.
+## Example: after configuring 6 faces, pass an Array of size 6.
+func set_face_values(new_face_values: Array[int]) -> void:
+	if data == null:
+		push_error("DieData has not been initialized. Call configure_with_sequential_faces first.")
+		return
 
+	if new_face_values.size() != data.faces.size():
+		push_error("Face count mismatch!")
+		return
+
+	for i in range(new_face_values.size()):
+		data.faces[i].face_value = new_face_values[i]
+
+
+## Internal helper that creates blank [FaceData] entries.
+func _initialize_faces(face_count: int) -> DieData:
+	data.faces = []
 	for i in range(face_count):
 		data.faces.append(FaceData.new())
-
 	return data
 
 
-func apply_face_value(new_face_values: Array[int]) -> void:
-	if new_face_values.size() == data.faces.size():
-		for i in range(new_face_values.size()):
-			data.faces[i].face_value = new_face_values[i]
-	else:
-		push_error("Face count mismatch!")
-
-
+## Rolls the die and returns the selected [FaceData].
+##
+## Returns `null` if the die has not been configured.
 func roll() -> FaceData:
 	if data == null or data.faces.is_empty():
 		push_error("DieData not configured!")
 		return null
-	
+
 	current_face = data.faces.pick_random()
 	rolled.emit(current_face)
 	return current_face

--- a/features/dice/die/die_ui.gd
+++ b/features/dice/die/die_ui.gd
@@ -1,25 +1,59 @@
 extends Control
+## Visual/controller wrapper for a single [DieInstance].
+##
+## Responsibilities:
+## - hold/select state for reroll behavior
+## - show the current face value in UI
+## - expose a safe roll entry point for scene scripts
 class_name DieUI
 
-signal die_rolled
+## Emitted when a roll happens from this UI control.
+## [param face] is the rolled face.
+signal die_rolled(face: FaceData)
 
 @onready var _face_label: Label = $Panel/FaceLabel
 @onready var _select_button: Button = $Panel/SelectButton
 
+## Runtime die backing this control.
 var die: DieInstance
+## If true, the die is "held" and should not roll.
+var is_selected: bool = false
 
-var is_selected : bool = false
 
-func _ready():
+func _ready() -> void:
 	_select_button.pressed.connect(_on_select_pressed)
 
-func _on_select_pressed():
-	is_selected = !is_selected
 
-func roll():
-	if !is_selected:
-		var roll_face : FaceData
-		roll_face = die.roll()
-		die_rolled.emit()
-		
-		_face_label.text = str(roll_face.face_value)
+## Assigns the die used by this UI.
+## If the die already has a current face, the label is immediately updated.
+func set_die(new_die: DieInstance) -> void:
+	die = new_die
+	if die.current_face != null:
+		_face_label.text = str(die.current_face.face_value)
+
+
+## Rolls only when this die is not selected/held.
+##
+## Returns:
+## - [FaceData] when a roll succeeds
+## - `null` when held, unassigned, or die config is invalid
+func roll_if_not_selected() -> FaceData:
+	if is_selected:
+		return null
+
+	if die == null:
+		push_error("DieUI has no DieInstance assigned.")
+		return null
+
+	var roll_face := die.roll()
+	if roll_face == null:
+		return null
+
+	_face_label.text = str(roll_face.face_value)
+	die_rolled.emit(roll_face)
+	return roll_face
+
+
+## Toggles hold/select state for this die.
+func _on_select_pressed() -> void:
+	is_selected = !is_selected

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,12 +1,15 @@
 extends Control
 
-var dieui : DieUI
+## Example scene wiring for one DieUI control.
+var die_ui: DieUI
+
 
 func _ready() -> void:
-	dieui = $Die
-	dieui.die = DieInstance.new()
-	
-	dieui.die.make_basic_die(6)
+	die_ui = $Die
+	# Quick-start path: create a standard d6 and bind it to the UI control.
+	die_ui.set_die(DieInstance.create_standard_d6())
+
 
 func _on_button_pressed() -> void:
-	dieui.roll()
+	# Rolls only if the die is not currently selected/held.
+	die_ui.roll_if_not_selected()


### PR DESCRIPTION
### Motivation

- Provide a clear, testable runtime die object and a safer UI entry point to simplify scripting and hold/roll interactions for dice-based gameplay.
- Centralize common die setup and expose convenient helpers so scenes don't need to manipulate raw `DieData` directly.

### Description

- Add a `DieInstance` runtime node with `signal rolled(face: FaceData)`, `current_face`, `create_standard_d6()`, `configure_with_sequential_faces()`, `set_face_values()`, `_initialize_faces()`, and an improved `roll()` that sets `current_face` and emits `rolled`.
- Replace previous ad-hoc die setup with clear initialization and validation paths and explicit error messages when `DieData` is not configured or face counts mismatch.
- Update `DieUI` to a proper controller with `signal die_rolled(face: FaceData)`, `set_die()`, `roll_if_not_selected()`, and `is_selected` toggle behavior, and make the UI update the displayed face when appropriate.
- Wire an example in `scenes/main.gd` to use `DieInstance.create_standard_d6()` and `DieUI.roll_if_not_selected()` and add Developer API notes to `README.md` documenting the recommended flow and helper functions.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6eae70e388331b4b2517858bf780a)