### PR TITLE
Refactor gameplay flow for modular GameState and event-driven dice

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,24 @@ Helpful APIs:
 - `DieUI.die_rolled(face)`: UI-level signal emitted after successful rolls.
 
 This gives you a clean default path while still allowing custom dice behavior when needed.
+
+## Modularity Notes (New)
+
+To keep future changes safe and readable, the project now follows this split:
+
+- `GameState` (autoload): owns round/run rules and mutable gameplay state.
+- `EventBus` (autoload): global decoupled events between feature modules.
+- `Hand` scene: owns only hand-level UI behavior (spawn dice, reroll interactions, play hand).
+- `DieUI`: owns single-die interaction state (held vs not held) and view updates.
+- `Main` scene script: orchestration layer that reacts to hand events and updates game state.
+
+### Practical extension strategy
+
+When adding a mechanic, use this order:
+
+1. Add/adjust rules in `autoload/game_state.gd`.
+2. Add cross-feature signals in `autoload/event_bus.gd` only if needed.
+3. Keep scene scripts thin (UI + signal wiring).
+4. Keep scoring/evaluation logic in one place (currently `scenes/main.gd`, can be moved to a dedicated scorer next).
+
+This makes balancing and new features (shop, trinkets, custom dice) easier without rewriting UI code.

--- a/autoload/game_state.gd
+++ b/autoload/game_state.gd
@@ -1,1 +1,92 @@
 extends Node
+class_name GameState
+
+## Centralized, runtime-only game state.
+##
+## Why this exists:
+## - keeps round/run rules in one place
+## - avoids scattering "magic numbers" through scene scripts
+## - makes feature additions (shop, trinkets, scaling tweaks) safer
+
+signal run_started(round_index: int)
+signal round_started(round_index: int, quota: int, hands: int, rerolls: int)
+signal round_state_changed(state: Dictionary)
+signal round_completed(round_index: int)
+signal run_failed(round_index: int)
+
+const BASE_QUOTA: int = 100
+const QUOTA_GROWTH: float = 1.45
+const BASE_HANDS_PER_ROUND: int = 4
+const HANDS_SCALING_INTERVAL: int = 3
+const BASE_REROLLS_PER_ROUND: int = 3
+
+var round_index: int = 1
+var quota_remaining: int = 0
+var hands_remaining: int = 0
+var rerolls_remaining: int = 0
+
+func _ready() -> void:
+	start_new_run()
+
+func start_new_run() -> void:
+	round_index = 1
+	run_started.emit(round_index)
+	start_round(round_index)
+
+func start_next_round() -> void:
+	round_index += 1
+	start_round(round_index)
+
+func start_round(target_round: int) -> void:
+	quota_remaining = _calculate_quota(target_round)
+	hands_remaining = _calculate_hands(target_round)
+	rerolls_remaining = BASE_REROLLS_PER_ROUND
+	round_started.emit(target_round, quota_remaining, hands_remaining, rerolls_remaining)
+	_emit_round_state()
+
+func consume_reroll() -> bool:
+	if rerolls_remaining <= 0:
+		return false
+	rerolls_remaining -= 1
+	_emit_round_state()
+	return true
+
+func apply_score_to_quota(score: int) -> void:
+	quota_remaining = max(quota_remaining - score, 0)
+	_emit_round_state()
+
+func consume_hand() -> void:
+	hands_remaining = max(hands_remaining - 1, 0)
+	_emit_round_state()
+	_evaluate_round_outcome()
+
+func is_round_complete() -> bool:
+	return quota_remaining <= 0
+
+func can_continue_round() -> bool:
+	return quota_remaining > 0 and hands_remaining > 0
+
+func _calculate_quota(target_round: int) -> int:
+	return int(round(BASE_QUOTA * pow(QUOTA_GROWTH, target_round - 1)))
+
+func _calculate_hands(target_round: int) -> int:
+	return BASE_HANDS_PER_ROUND + int((target_round - 1) / HANDS_SCALING_INTERVAL)
+
+func _emit_round_state() -> void:
+	round_state_changed.emit(get_round_state())
+
+func get_round_state() -> Dictionary:
+	return {
+		"round_index": round_index,
+		"quota_remaining": quota_remaining,
+		"hands_remaining": hands_remaining,
+		"rerolls_remaining": rerolls_remaining,
+	}
+
+func _evaluate_round_outcome() -> void:
+	if is_round_complete():
+		round_completed.emit(round_index)
+		return
+
+	if hands_remaining <= 0:
+		run_failed.emit(round_index)

--- a/features/dice/die/die_ui.gd
+++ b/features/dice/die/die_ui.gd
@@ -22,7 +22,7 @@ var is_selected: bool = false
 func set_die(new_die: DieInstance) -> void:
 	die = new_die
 	if die.current_face != null:
-		text = str(die.current_face.face_value)
+		text = str(die.current_face.value)
 
 
 ## Rolls only when this die is not selected/held.
@@ -44,9 +44,11 @@ func roll_if_not_selected() -> FaceData:
 
 	text = str(roll_face.value)
 	die_rolled.emit(roll_face)
+	EventBus.roll_die.emit(self)
 	return roll_face
 
 ## Toggles hold/select state for this die.
 func _on_toggled(selected: bool) -> void:
 	is_selected = selected
 	die_selected.emit(self)
+	EventBus.select_die.emit(self)

--- a/features/dice/hand/hand.gd
+++ b/features/dice/hand/hand.gd
@@ -2,30 +2,38 @@ extends Control
 
 @onready var hand_container = $HBoxContainer/Panel/HandContainer
 @export var die_ui_scene: PackedScene
+@export var dice_per_hand: int = 5
 
 signal setup_complete
-signal played_hand_ready(dice : Array[DieUI])
+signal played_hand_ready(dice: Array[DieUI])
 signal played_hand_finished
 
-var dice : Array[DieUI] = []
+var dice: Array[DieUI] = []
 
 func _ready() -> void:
-	for i in range(5):
-		var die_ui : DieUI = die_ui_scene.instantiate()
-		hand_container.add_child(die_ui)
-
-		die_ui.set_die(DieInstance.create_standard_d6())
-		die_ui.roll_if_not_selected()
-
-		dice.append(die_ui)
+	_build_hand(dice_per_hand)
+	if not EventBus.roll_all_dice_requested.is_connected(_roll_unselected_dice):
+		EventBus.roll_all_dice_requested.connect(_roll_unselected_dice)
 	setup_complete.emit()
 
-func _on_roll_pressed() -> void:
+func _build_hand(dice_count: int) -> void:
+	for i in range(dice_count):
+		var die_ui: DieUI = die_ui_scene.instantiate()
+		hand_container.add_child(die_ui)
+		die_ui.set_die(DieInstance.create_standard_d6())
+		die_ui.roll_if_not_selected()
+		dice.append(die_ui)
+
+func _roll_unselected_dice() -> void:
 	for die in dice:
 		die.roll_if_not_selected()
+
+func _on_roll_pressed() -> void:
+	if GameState.consume_reroll():
+		EventBus.roll_all_dice_requested.emit()
 
 func _on_hand_animator_play_animation_finished() -> void:
 	played_hand_ready.emit(dice)
 
-func _on_played_hand_finish():
+func _on_played_hand_finish() -> void:
 	played_hand_finished.emit()

--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,7 @@ config/icon="res://assets/sprites/icon.svg"
 [autoload]
 
 EventBus="*uid://daxbdt73sgi6o"
+GameState="*res://autoload/game_state.gd"
 
 [physics]
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,1 +1,36 @@
 extends Control
+
+@onready var hand: Control = $MarginContainer/Hand
+
+func _ready() -> void:
+	hand.played_hand_ready.connect(_on_played_hand_ready)
+	GameState.round_started.connect(_on_round_started)
+	GameState.round_completed.connect(_on_round_completed)
+	GameState.run_failed.connect(_on_run_failed)
+	GameState.round_state_changed.connect(_on_round_state_changed)
+
+func _on_played_hand_ready(dice: Array[DieUI]) -> void:
+	var score := _calculate_hand_score(dice)
+	GameState.apply_score_to_quota(score)
+	GameState.consume_hand()
+	hand._on_played_hand_finish()
+
+func _calculate_hand_score(dice: Array[DieUI]) -> int:
+	var total := 0
+	for die in dice:
+		if die.die != null and die.die.current_face != null:
+			total += die.die.current_face.value
+	return total
+
+func _on_round_started(round_index: int, quota: int, hands: int, rerolls: int) -> void:
+	print("Round %d started | quota=%d hands=%d rerolls=%d" % [round_index, quota, hands, rerolls])
+
+func _on_round_completed(round_index: int) -> void:
+	print("Round %d complete" % round_index)
+	GameState.start_next_round()
+
+func _on_run_failed(round_index: int) -> void:
+	print("Run failed on round %d" % round_index)
+
+func _on_round_state_changed(state: Dictionary) -> void:
+	print("State: ", state)


### PR DESCRIPTION
### Motivation

- Centralize round/run rules and tuning so balance numbers are not scattered across scene scripts.
- Decouple UI (hand/die) behavior from gameplay rules to make features and testing easier to add or modify.
- Provide a clear orchestration layer for scoring and round progression to improve readability and extension points.

### Description

- Added a new `GameState` autoload (`autoload/game_state.gd`) that owns runtime state, tuning constants, and lifecycle signals for rounds and runs.  
- Registered `GameState` in `project.godot` autoloads so scenes can access a single authoritative game state.  
- Refactored the `Hand` scene script (`features/dice/hand/hand.gd`) to be configurable (`dice_per_hand`), to build dice via a `_build_hand` helper, and to trigger rerolls through `EventBus` gated by `GameState.consume_reroll()`.  
- Updated `DieUI` (`features/dice/die/die_ui.gd`) to initialize face text from the correct property (`value`) and emit global roll/select events on the `EventBus`.  
- Implemented `Main` orchestration (`scenes/main.gd`) that listens to hand/game-state signals, computes hand score, applies score to quota, consumes hands, and advances rounds.  
- Expanded `README.md` with modularity notes and a practical extension strategy for future mechanics.

### Testing

- Ran whitespace/format check using `git diff --check` and it completed without reported issues.  
- Verified repository change visibility with `git status --short` which showed the updated files staged/changed.  
- Attempted to run `godot --version` to perform runtime checks but the `godot` binary is not available in this environment, so runtime validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98e8a53e48331bb2c726d02843fee)