### PR TITLE
Integrate ScoreManager into main hand resolution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,6 @@ When adding a mechanic, use this order:
 1. Add/adjust rules in `autoload/game_state.gd`.
 2. Add cross-feature signals in `autoload/event_bus.gd` only if needed.
 3. Keep scene scripts thin (UI + signal wiring).
-4. Keep scoring/evaluation logic in one place (currently `scenes/main.gd`, can be moved to a dedicated scorer next).
+4. Keep scoring/evaluation logic centralized in `core/node_classes/score_manager.gd`, and keep scene scripts focused on orchestration/UI wiring.
 
 This makes balancing and new features (shop, trinkets, custom dice) easier without rewriting UI code.

--- a/autoload/event_bus.gd
+++ b/autoload/event_bus.gd
@@ -11,3 +11,19 @@ signal roll_die(die_ui : DieUI)
 
 @warning_ignore("unused_signal")
 signal select_die(die_ui : DieUI)
+
+# Emitted when a hand has been evaluated into details (type + scoring groups).
+@warning_ignore("unused_signal")
+signal hand_evaluated(details: HandDetails)
+
+# Emitted after score preview is calculated for a hand.
+@warning_ignore("unused_signal")
+signal score_calculated(details: HandDetails, type_total: int, breakdown: Dictionary)
+
+# Emitted when a played hand's round score is applied.
+@warning_ignore("unused_signal")
+signal round_score_applied(score: int)
+
+# Emitted when score manager commits cumulative run score.
+@warning_ignore("unused_signal")
+signal score_committed(total_score: int)

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -2,7 +2,12 @@ extends Control
 
 @onready var hand: Control = $MarginContainer/Hand
 
+var score_manager: ScoreManager
+
 func _ready() -> void:
+	score_manager = ScoreManager.new()
+	add_child(score_manager)
+
 	hand.played_hand_ready.connect(_on_played_hand_ready)
 	GameState.round_started.connect(_on_round_started)
 	GameState.round_completed.connect(_on_round_completed)
@@ -10,18 +15,29 @@ func _ready() -> void:
 	GameState.round_state_changed.connect(_on_round_state_changed)
 
 func _on_played_hand_ready(dice: Array[DieUI]) -> void:
-	var score := _calculate_hand_score(dice)
-	GameState.apply_score_to_quota(score)
+	var hand_values := _extract_dice_values(dice)
+	score_manager.preview_hand(hand_values)
+
+	if not score_manager.can_play_hand():
+		GameState.consume_hand()
+		await get_tree().create_timer(1).timeout
+		hand._on_played_hand_finish()
+		return
+
+	score_manager.play_hand()
+	var applied_score := score_manager.commit_played_hand()
+	GameState.apply_score_to_quota(applied_score)
 	GameState.consume_hand()
+
 	await get_tree().create_timer(1).timeout
 	hand._on_played_hand_finish()
 
-func _calculate_hand_score(dice: Array[DieUI]) -> int:
-	var total := 0
+func _extract_dice_values(dice: Array[DieUI]) -> Array[int]:
+	var values: Array[int] = []
 	for die in dice:
 		if die.die != null and die.die.current_face != null:
-			total += die.die.current_face.value
-	return total
+			values.append(die.die.current_face.value)
+	return values
 
 func _on_round_started(round_index: int, quota: int, hands: int, rerolls: int) -> void:
 	print("Round %d started | quota=%d hands=%d rerolls=%d" % [round_index, quota, hands, rerolls])


### PR DESCRIPTION
### Motivation
- Centralize scoring logic so scene scripts remain thin and orchestration-focused by using the new score-management scripts.
- Decouple evaluation and scoring from UI flow so score systems can expose previews, breakdowns, and commit semantics.
- Expose score-related events on the global bus to allow other systems (HUD, trinkets, shop) to respond without tight coupling.

### Description
- `scenes/main.gd` now instantiates `ScoreManager` and routes played hands through the `preview -> can_play -> play -> commit` flow instead of inline face-sum scoring, using `ScoreManager` APIs (`preview_hand`, `can_play_hand`, `play_hand`, `commit_played_hand`).
- Replaced the inline `_calculate_hand_score` with an `_extract_dice_values` helper that produces an `Array[int]` passed into the score manager as the canonical input.
- Added score/evaluation signals to `autoload/event_bus.gd` (`hand_evaluated`, `score_calculated`, `round_score_applied`, `score_committed`) so scoring modules can communicate via the global `EventBus`.
- Updated `README.md` guidance to state that scoring/evaluation is centralized in `core/node_classes/score_manager.gd` and that scene scripts should focus on orchestration and UI wiring.

### Testing
- Ran a headless project integrity check with `godot --headless --check-only --path /workspace/Navatra`, which failed because the `godot` binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa57e21d4c83319aef2c36b2fd4f5c)