### PR TITLE
Log played hand name and points in main script

### DIFF
--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -25,7 +25,9 @@ func _on_played_hand_ready(dice: Array[DieUI]) -> void:
 		return
 
 	score_manager.play_hand()
+	var played_hand_name := _get_played_hand_name()
 	var applied_score := score_manager.commit_played_hand()
+	print("Played hand: %s | points=%d" % [played_hand_name, applied_score])
 	GameState.apply_score_to_quota(applied_score)
 	GameState.consume_hand()
 
@@ -38,6 +40,10 @@ func _extract_dice_values(dice: Array[DieUI]) -> Array[int]:
 		if die.die != null and die.die.current_face != null:
 			values.append(die.die.current_face.value)
 	return values
+
+func _get_played_hand_name() -> String:
+	var breakdown := score_manager.get_last_breakdown()
+	return str(breakdown.get("hand_name", "Unknown"))
 
 func _on_round_started(round_index: int, quota: int, hands: int, rerolls: int) -> void:
 	print("Round %d started | quota=%d hands=%d rerolls=%d" % [round_index, quota, hands, rerolls])


### PR DESCRIPTION
### Motivation
- Provide immediate console visibility of the evaluated hand name and the number of points applied when a hand is played and committed in the main game flow.

### Description
- In `scenes/main.gd` call a new helper `_get_played_hand_name()` before committing the played hand and print `Played hand: <name> | points=<score>` to the console after `score_manager.commit_played_hand()`.
- Added `_get_played_hand_name()` which reads `hand_name` from `score_manager.get_last_breakdown()` and safely defaults to `"Unknown"` if missing.

### Testing
- Ran `git diff --check` which completed successfully and the change was committed; no further automated tests exist for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5bf28c7c83318a2535bf028eaa15)