### PR TITLE
Populate main UI labels and animate only scoring dice for played hands

### DIFF
--- a/features/dice/hand/hand_animator.gd
+++ b/features/dice/hand/hand_animator.gd
@@ -5,6 +5,8 @@ extends Node
 signal play_animation_finished
 signal hand_reset_ready
 
+var hand_evaluator := HandEvaluatorService.new()
+
 func _on_hand_setup_complete() -> void:
 	for die : DieUI in hand.dice:
 		die.die_selected.connect(_on_die_selected)
@@ -19,18 +21,62 @@ func _on_die_selected(die_ui: DieUI):
 
 func _on_play_pressed() -> void:
 	var tweens: Array[Tween] = []
-	
-	#I want to only animate the dice that are apart of the hand type
-	for die: DieUI in hand.dice:
+	var target_dice := _get_scoring_dice()
+
+	for die: DieUI in target_dice:
 		var tween = create_tween()
 		tween.tween_property(die, "position:y", -200, 0.2)
 		tweens.append(tween)
-		
+
 	for tween in tweens:
 		await tween.finished
-	
+
 	play_animation_finished.emit()
 
+func _get_scoring_dice() -> Array[DieUI]:
+	if hand == null or hand.dice.is_empty():
+		return []
+
+	var values: Array[int] = []
+	for die: DieUI in hand.dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		values.append(die.die.current_face.value)
+
+	if values.size() != hand.dice.size():
+		return hand.dice.duplicate()
+
+	var details := hand_evaluator.get_hand_details(values)
+	if details == null or details.groups.is_empty():
+		return hand.dice.duplicate()
+
+	var counts_needed := _get_counts_needed(details)
+	if counts_needed.is_empty():
+		return hand.dice.duplicate()
+
+	var scoring_dice: Array[DieUI] = []
+	for die: DieUI in hand.dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		var value := die.die.current_face.value
+		var remaining := int(counts_needed.get(value, 0))
+		if remaining > 0:
+			scoring_dice.append(die)
+			counts_needed[value] = remaining - 1
+
+	if scoring_dice.is_empty():
+		return hand.dice.duplicate()
+
+	return scoring_dice
+
+func _get_counts_needed(details: HandDetails) -> Dictionary:
+	var counts_needed := {}
+	for group_data in details.groups:
+		for group_name in group_data.keys():
+			var group_values: Array = group_data[group_name]
+			for value in group_values:
+				counts_needed[value] = int(counts_needed.get(value, 0)) + 1
+	return counts_needed
 
 func _on_hand_played_hand_finished() -> void:
 	var tweens: Array[Tween] = []

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -19,7 +19,9 @@ func _ready() -> void:
 	GameState.round_completed.connect(_on_round_completed)
 	GameState.run_failed.connect(_on_run_failed)
 	GameState.round_state_changed.connect(_on_round_state_changed)
-	
+	EventBus.score_calculated.connect(_on_score_calculated)
+
+	ui_update()
 	
 
 func _on_played_hand_ready(hand_data: DiceHand) -> void:
@@ -57,7 +59,22 @@ func _on_run_failed(round_index: int) -> void:
 
 func _on_round_state_changed(state: Dictionary) -> void:
 	print("State: ", state)
+	ui_update(state)
 
-func ui_update():
-	#update  all the label vars
-	pass
+func _on_score_calculated(_details: HandDetails, _type_total: int, _breakdown: Dictionary) -> void:
+	ui_update()
+
+func ui_update(state: Dictionary = {}) -> void:
+	if state.is_empty():
+		state = GameState.get_round_state()
+
+	var breakdown := score_manager.get_last_breakdown()
+	var hand_name := str(breakdown.get("hand_name", "-"))
+	var type_total := int(breakdown.get("type_total", 0))
+
+	quota_label.text = "Quota: %d" % int(state.get("quota_remaining", 0))
+	current_hand_points_label.text = "Current Hand Points: %d" % type_total
+	hand_type_label.text = "Hand Type: %s" % hand_name
+	hand_type_value_label.text = "Hand Type Value: %d" % type_total
+	hands_left_leabel.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))
+	rolls_left_label.text = "Rolls Left: %d" % int(state.get("rerolls_remaining", 0))


### PR DESCRIPTION
### Motivation
- Keep the main UI labels in sync with live round state and the last-evaluated hand so players see accurate quota/hand information immediately.
- Make the hand play animation only target the dice that contribute to the evaluated hand (pair/trips/straight/etc.) so the visual feedback matches the scoring logic.

### Description
- Implemented `ui_update(state := {})` in `scenes/main.gd` to populate the quota, current hand points, hand type name, hand type value, hands left, and rolls left labels from `GameState` and the score manager breakdown.
- Subscribed the main scene to `EventBus.score_calculated` and updated handling of `GameState.round_state_changed` so the UI refreshes automatically when score previews or round state change.
- Added evaluation-driven selection in `features/dice/hand/hand_animator.gd` using `HandEvaluatorService` and `HandDetails.groups` to compute which `DieUI` instances actually contribute to the hand and animate only those dice, with a fallback to animate all dice if details are incomplete.
- Added helper functions `._get_scoring_dice()` and `._get_counts_needed()` to convert `HandDetails.groups` into per-value counts and pick matching dice deterministically.

### Testing
- Applied and inspected the modified files `scenes/main.gd` and `features/dice/hand/hand_animator.gd` and verified the intended edits via file diff and file prints, which showed the new UI wiring and scoring-only animation logic present.
- Confirmed the patch applied cleanly to the repository files on disk without errors.
- Attempted to run the Godot CLI (`command -v godot4 || command -v godot`) but it is not available in this environment so runtime integration/scene execution tests could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abb5f6e370833196b03b1f47d1c335)