### PR TITLE
Refresh hand preview so HUD hand type/value update on rolls

### DIFF
--- a/features/dice/hand/hand.gd
+++ b/features/dice/hand/hand.gd
@@ -45,6 +45,10 @@ func _build_dice_hand() -> DiceHand:
 			values.append(die_ui.die.current_face.value)
 	return DiceHand.new(values)
 
+
+func get_current_hand() -> DiceHand:
+	return _build_dice_hand()
+
 func _on_played_hand_finish() -> void:
 	played_hand_finished.emit()
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,6 +1,6 @@
 extends Control
 
-@onready var hand: Control = $MarginContainer/Hand
+@onready var hand: Node = $MarginContainer/Hand
 @onready var round_index_label: Label = $VBoxContainer/RoundIndex
 @onready var quota_label: Label = $VBoxContainer/Quota
 @onready var current_hand_points_label: Label = $VBoxContainer/CurrentHandPoints
@@ -21,6 +21,8 @@ func _ready() -> void:
 	GameState.run_failed.connect(_on_run_failed)
 	GameState.round_state_changed.connect(_on_round_state_changed)
 	EventBus.roll_all_dice_requested.connect(_on_roll_all_dice_requested)
+
+	_refresh_hand_preview()
 	ui_update()
 	
 
@@ -61,8 +63,23 @@ func _on_round_state_changed(state: Dictionary) -> void:
 	print("State: ", state)
 	ui_update(state)
 
-func _on_roll_all_dice_requested():
+func _on_roll_all_dice_requested() -> void:
+	_refresh_hand_preview()
 	ui_update()
+
+
+func _refresh_hand_preview() -> void:
+	if hand == null or score_manager == null:
+		return
+
+	if not hand.has_method("get_current_hand"):
+		return
+
+	var current_hand: DiceHand = hand.call("get_current_hand")
+	if current_hand == null:
+		return
+
+	score_manager.preview_hand(current_hand.to_array())
 
 func ui_update(state: Dictionary = {}) -> void:
 	if state.is_empty():


### PR DESCRIPTION
### Motivation
- The HUD labels for `Hand Type`, `Hand Type Value`, and `Current Hand Points` were showing stale values because the score preview wasn't refreshed when dice were rolled or on scene startup.

### Description
- Added a public `get_current_hand()` method to `features/dice/hand/hand.gd` that returns a `DiceHand` snapshot of the current dice values.
- Changed the `hand` reference in `scenes/main.gd` to `Node` and implemented a `_refresh_hand_preview()` helper that safely calls `get_current_hand()` and passes the result to `score_manager.preview_hand(...)`.
- Call `_refresh_hand_preview()` from `_ready()` before `ui_update()` and from the `roll_all_dice_requested` handler so the preview/breakdown is refreshed prior to updating labels.
- Left the existing `ui_update()` logic intact so labels continue to read from `score_manager.get_last_breakdown()` after the preview is refreshed.

### Testing
- Ran `godot --headless --quit` to validate runtime, which failed because `godot` is not installed in this environment (failed).
- Inspected modified files with `nl`/`sed` and `git diff` to confirm the expected changes exist in `features/dice/hand/hand.gd` and `scenes/main.gd` (succeeded).
- Ran `git status` to confirm working tree changes were tracked (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abba64490c83319dc7063124006883)