### PR TITLE
Fix Current Hand Points to show applied hand score

### DIFF
--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -88,10 +88,11 @@ func ui_update(state: Dictionary = {}) -> void:
 	var breakdown := score_manager.get_last_breakdown()
 	var hand_name := str(breakdown.get("hand_name", "-"))
 	var type_total := int(breakdown.get("type_total", 0))
+	var final_score := int(breakdown.get("final_score", 0))
 	
 	round_index_label.text = "Round %d" % state.get("round_index", 0)
 	quota_label.text = "Quota: %d" % int(state.get("quota_remaining", 0))
-	current_hand_points_label.text = "Current Hand Points: %d" % type_total
+	current_hand_points_label.text = "Current Hand Points: %d" % final_score
 	hand_type_label.text = "Hand Type: %s" % hand_name
 	hand_type_value_label.text = "Hand Type Value: %d" % type_total
 	hands_left_leabel.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))


### PR DESCRIPTION
### Motivation
- The UI label "Current Hand Points" displayed the hand type-only total instead of the actual score applied to the quota, causing a mismatch between displayed points and quota subtraction.

### Description
- Updated `ui_update` in `scenes/main.gd` to read `final_score` from the score breakdown and use it for the `Current Hand Points` label, while keeping `Hand Type Value` bound to `type_total`.

### Testing
- Ran `git diff --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6c780a8883319ef733e66b90bc20)