### PR TITLE
Fix hand scene button wiring and split Hand vs Animator responsibilities

### DIFF
--- a/features/dice/hand/hand.gd
+++ b/features/dice/hand/hand.gd
@@ -1,13 +1,14 @@
 extends Control
 
 @onready var hand_container = $HBoxContainer/Panel/HandContainer
+@onready var hand_animator: Node = $HandAnimator
 @export var die_ui_scene: PackedScene
 @export var dice_per_hand: int = 5
 @export var play_button: Button
 @export var roll_button: Button
 
-
 var is_hand_ready: bool = false
+var hand_evaluator := HandEvaluatorService.new()
 
 signal setup_complete
 signal played_hand_ready(hand: DiceHand)
@@ -19,9 +20,14 @@ func _ready() -> void:
 	_build_hand(dice_per_hand)
 	if not EventBus.roll_all_dice_requested.is_connected(_roll_unselected_dice):
 		EventBus.roll_all_dice_requested.connect(_roll_unselected_dice)
-	roll_button.pressed.connect(_on_roll_pressed)
-	
+
+	if roll_button != null and not roll_button.pressed.is_connected(_on_roll_pressed):
+		roll_button.pressed.connect(_on_roll_pressed)
+	if play_button != null and not play_button.pressed.is_connected(_on_play_pressed):
+		play_button.pressed.connect(_on_play_pressed)
+
 	setup_complete.emit()
+	is_hand_ready = true
 
 func _build_hand(dice_count: int) -> void:
 	for _i in range(dice_count):
@@ -36,15 +42,73 @@ func _roll_unselected_dice() -> void:
 		die.roll_if_not_selected()
 
 func _on_roll_pressed() -> void:
-	if GameState.consume_reroll() and GameState.get_round_state().get("rerolls_remaining", 0) >= 0 and is_hand_ready:
-		EventBus.roll_all_dice_requested.emit()
-		
+	if not is_hand_ready:
+		return
 
-func _on_hand_animator_play_animation_finished() -> void:
+	if GameState.consume_reroll():
+		EventBus.roll_all_dice_requested.emit()
+
+func _on_play_pressed() -> void:
+	if not is_hand_ready:
+		return
+
+	is_hand_ready = false
+	var animator: HandAnimator = hand_animator as HandAnimator
+	if animator == null:
+		push_error("HandAnimator node is missing or has incorrect script.")
+		is_hand_ready = true
+		return
+
+	await animator.play_hand(_get_scoring_dice())
 	for die in dice:
 		die.is_selected = false
 	played_hand_ready.emit(_build_dice_hand())
-	
+
+func _get_scoring_dice() -> Array[DieUI]:
+	if dice.is_empty():
+		return []
+
+	var values: Array[int] = []
+	for die: DieUI in dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		values.append(die.die.current_face.value)
+
+	if values.size() != dice.size():
+		return dice.duplicate()
+
+	var details := hand_evaluator.get_hand_details(values)
+	if details == null or details.groups.is_empty():
+		return dice.duplicate()
+
+	var counts_needed := _get_counts_needed(details)
+	if counts_needed.is_empty():
+		return dice.duplicate()
+
+	var scoring_dice: Array[DieUI] = []
+	for die: DieUI in dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		var value := die.die.current_face.value
+		var remaining := int(counts_needed.get(value, 0))
+		if remaining > 0:
+			scoring_dice.append(die)
+			counts_needed[value] = remaining - 1
+
+	if scoring_dice.is_empty():
+		return dice.duplicate()
+
+	return scoring_dice
+
+func _get_counts_needed(details: HandDetails) -> Dictionary:
+	var counts_needed := {}
+	for group_data in details.groups:
+		for group_name in group_data.keys():
+			var group_values: Array = group_data[group_name]
+			for value in group_values:
+				counts_needed[value] = int(counts_needed.get(value, 0)) + 1
+	return counts_needed
+
 
 func _build_dice_hand() -> DiceHand:
 	var values: Array[int] = []
@@ -52,7 +116,6 @@ func _build_dice_hand() -> DiceHand:
 		if die_ui.die != null and die_ui.die.current_face != null:
 			values.append(die_ui.die.current_face.value)
 	return DiceHand.new(values)
-
 
 func get_current_hand() -> DiceHand:
 	return _build_dice_hand()
@@ -62,3 +125,4 @@ func _on_played_hand_finish() -> void:
 
 func _on_hand_animator_hand_reset_ready() -> void:
 	EventBus.roll_all_dice_requested.emit()
+	is_hand_ready = true

--- a/features/dice/hand/hand.tscn
+++ b/features/dice/hand/hand.tscn
@@ -67,5 +67,3 @@ text = "Roll"
 [connection signal="played_hand_finished" from="." to="HandAnimator" method="_on_hand_played_hand_finished"]
 [connection signal="setup_complete" from="." to="HandAnimator" method="_on_hand_setup_complete"]
 [connection signal="hand_reset_ready" from="HandAnimator" to="." method="_on_hand_animator_hand_reset_ready"]
-[connection signal="play_animation_finished" from="HandAnimator" to="." method="_on_hand_animator_play_animation_finished"]
-[connection signal="pressed" from="HBoxContainer/ButtonContainer/play" to="HandAnimator" method="_on_play_pressed"]

--- a/features/dice/hand/hand_animator.gd
+++ b/features/dice/hand/hand_animator.gd
@@ -1,30 +1,27 @@
 extends Node
+class_name HandAnimator
 
 @onready var hand = $".."
 
 signal play_animation_finished
 signal hand_reset_ready
 
-var hand_evaluator := HandEvaluatorService.new()
-
 func _on_hand_setup_complete() -> void:
-	for die : DieUI in hand.dice:
+	for die: DieUI in hand.dice:
 		die.die_selected.connect(_on_die_selected)
 
-func _on_die_selected(die_ui: DieUI):
-	if die_ui.is_selected:
-		var tween = create_tween()
-		tween.tween_property(die_ui, "position:y", -100, 0.2)
-	else:
-		var tween = create_tween()
-		tween.tween_property(die_ui, "position:y", 0, 0.2)
+func _on_die_selected(die_ui: DieUI) -> void:
+	animate_die_selection(die_ui)
 
-func _on_play_pressed() -> void:
+func animate_die_selection(die_ui: DieUI) -> void:
+	var target_y := -100 if die_ui.is_selected else 0
+	var tween := create_tween()
+	tween.tween_property(die_ui, "position:y", target_y, 0.2)
+
+func play_hand(target_dice: Array[DieUI]) -> void:
 	var tweens: Array[Tween] = []
-	var target_dice := _get_scoring_dice()
-
 	for die: DieUI in target_dice:
-		var tween = create_tween()
+		var tween := create_tween()
 		tween.tween_property(die, "position:y", -200, 0.2)
 		tweens.append(tween)
 
@@ -33,55 +30,10 @@ func _on_play_pressed() -> void:
 
 	play_animation_finished.emit()
 
-func _get_scoring_dice() -> Array[DieUI]:
-	if hand == null or hand.dice.is_empty():
-		return []
-
-	var values: Array[int] = []
-	for die: DieUI in hand.dice:
-		if die.die == null or die.die.current_face == null:
-			continue
-		values.append(die.die.current_face.value)
-
-	if values.size() != hand.dice.size():
-		return hand.dice.duplicate()
-
-	var details := hand_evaluator.get_hand_details(values)
-	if details == null or details.groups.is_empty():
-		return hand.dice.duplicate()
-
-	var counts_needed := _get_counts_needed(details)
-	if counts_needed.is_empty():
-		return hand.dice.duplicate()
-
-	var scoring_dice: Array[DieUI] = []
-	for die: DieUI in hand.dice:
-		if die.die == null or die.die.current_face == null:
-			continue
-		var value := die.die.current_face.value
-		var remaining := int(counts_needed.get(value, 0))
-		if remaining > 0:
-			scoring_dice.append(die)
-			counts_needed[value] = remaining - 1
-
-	if scoring_dice.is_empty():
-		return hand.dice.duplicate()
-
-	return scoring_dice
-
-func _get_counts_needed(details: HandDetails) -> Dictionary:
-	var counts_needed := {}
-	for group_data in details.groups:
-		for group_name in group_data.keys():
-			var group_values: Array = group_data[group_name]
-			for value in group_values:
-				counts_needed[value] = int(counts_needed.get(value, 0)) + 1
-	return counts_needed
-
 func _on_hand_played_hand_finished() -> void:
 	var tweens: Array[Tween] = []
-	for die : DieUI in hand.dice:
-		var tween = create_tween()
+	for die: DieUI in hand.dice:
+		var tween := create_tween()
 		tween.tween_property(die, "position:y", 0, 0.2)
 		tweens.append(tween)
 	for tween in tweens:


### PR DESCRIPTION
### Motivation
- The Hand scene had UI input routed into the animator and mixed animation with gameplay evaluation, causing unclear ownership for play/roll actions.  
- Buttons were not consistently wired through the Hand controller which should own reroll/play gating and emit a `DiceHand` model for game flow.  
- The intent is to keep animation concerns isolated in an animator helper and keep gameplay/evaluation in the Hand controller per project layering rules.

### Description
- Connect `roll` and `play` button `pressed` signals inside `features/dice/hand/hand.gd` with safety checks and a `is_hand_ready` gate so input is handled by the Hand controller.  
- Move scoring-dice selection and related helpers (`_get_scoring_dice`, `_get_counts_needed`) from the animator into `hand.gd` so the Hand owns gameplay-facing evaluation.  
- Add an `@onready var hand_animator` reference and call the animator via the new `play_hand(target_dice)` API; the animator now focuses on tweens only.  
- Reduce `features/dice/hand/hand_animator.gd` to animation responsibilities, add `class_name HandAnimator`, expose `play_hand(...)`, and keep selection/reset tweens there.  
- Update `features/dice/hand/hand.tscn` to remove the direct `play` button → `HandAnimator` pressed connection and preserve lifecycle connections (`setup_complete`, `played_hand_finished`, `hand_reset_ready`).

### Testing
- Ran a project script to ensure the scene/script files were updated and saved to disk (file edits inspected by `sed`/`nl` outputs).  
- Verified via pattern search (`rg`) that `play` button no longer connects directly to the animator and that `roll_button`/`play_button` wiring exists in `hand.gd`.  
- Attempted a headless Godot script check with `godot --headless --check-only --quit`, but it failed in this environment because the `godot` CLI is not installed.  
- No runtime engine tests could be executed here due to the missing Godot binary; changes are syntactically localized and follow the project layering model for manual verification in-engine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc7a9ddc83319295a6b4d7d4a428)