### PR TITLE
Reset run to round 1 on run failure

### DIFF
--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -58,6 +58,7 @@ func _on_round_completed(round_index: int) -> void:
 
 func _on_run_failed(round_index: int) -> void:
 	print("Run failed on round %d" % round_index)
+	GameState.start_new_run()
 
 func _on_round_state_changed(state: Dictionary) -> void:
 	print("State: ", state)


### PR DESCRIPTION
### Motivation
- Ensure that when a run is lost (for example a played hand yields 0 points while the quota is still unmet and hands are exhausted) the game resets progression back to round/level 1 by starting a fresh run.

### Description
- Add a call to `GameState.start_new_run()` in the `_on_run_failed` callback in `scenes/main.gd` so the game immediately starts a new run when a run fails.

### Testing
- Verified the change with `git status --short && git diff -- scenes/main.gd` which showed the single-line addition and the diff succeeded; the file `scenes/main.gd` was committed. 
- Inspected the modified region with `nl -ba scenes/main.gd | sed -n '52,72p'` to confirm `GameState.start_new_run()` is present in `_on_run_failed` and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbf3dbe1c83318e816b844d437dda)