### PR TITLE
Add reward system and in-round reward shop (score multiplier, hands/rerolls/quota rewards)

### DIFF
--- a/autoload/game_state.gd
+++ b/autoload/game_state.gd
@@ -10,6 +10,7 @@ signal run_started(round_index: int)
 signal round_started(round_index: int, quota: int, hands: int, rerolls: int)
 signal round_state_changed(state: Dictionary)
 signal round_completed(round_index: int)
+signal reward_phase_started
 signal run_failed(round_index: int)
 
 const BASE_QUOTA: int = 300
@@ -22,6 +23,7 @@ var round_index: int = 1
 var quota_remaining: int = 0
 var hands_remaining: int = 0
 var rerolls_remaining: int = 0
+var round_score_multiplier: float = 1.0
 
 func _ready() -> void:
 	start_new_run()
@@ -39,6 +41,7 @@ func start_round(target_round: int) -> void:
 	quota_remaining = _calculate_quota(target_round)
 	hands_remaining = _calculate_hands(target_round)
 	rerolls_remaining = BASE_REROLLS_PER_ROUND
+	round_score_multiplier = 1.0
 	round_started.emit(target_round, quota_remaining, hands_remaining, rerolls_remaining)
 	_emit_round_state()
 
@@ -79,11 +82,13 @@ func get_round_state() -> Dictionary:
 		"quota_remaining": quota_remaining,
 		"hands_remaining": hands_remaining,
 		"rerolls_remaining": rerolls_remaining,
+		"round_score_multiplier": round_score_multiplier,
 	}
 
 func _evaluate_round_outcome() -> void:
 	if is_round_complete():
 		round_completed.emit(round_index)
+		reward_phase_started.emit()
 		return
 
 	if hands_remaining <= 0:

--- a/core/node_classes/score_manager.gd
+++ b/core/node_classes/score_manager.gd
@@ -53,8 +53,8 @@ func commit_played_hand() -> int:
 	if not play_pending:
 		return 0
 
-	current_score += last_roll_score
-	var applied_round_score := last_roll_score
+	var applied_round_score := int(round(last_roll_score * GameState.round_score_multiplier))
+	current_score += applied_round_score
 
 	EventBus.round_score_applied.emit(applied_round_score)
 	EventBus.score_committed.emit(current_score)

--- a/core/resources/reward_definition.gd
+++ b/core/resources/reward_definition.gd
@@ -1,0 +1,15 @@
+class_name RewardDefinition
+extends Resource
+
+enum RewardType {
+	ADD_HAND,
+	ADD_REROLL,
+	ADD_SCORE,
+	SCORE_MULT,
+}
+
+@export var id: String = ""
+@export var title: String = ""
+@export_multiline var description: String = ""
+@export var type: RewardType = RewardType.ADD_HAND
+@export var value: float = 0.0

--- a/core/services/reward_service.gd
+++ b/core/services/reward_service.gd
@@ -1,0 +1,78 @@
+extends RefCounted
+class_name RewardService
+
+var _reward_pool: Array[RewardDefinition] = []
+
+func _init() -> void:
+	_build_default_reward_pool()
+
+func generate_rewards(count: int) -> Array[RewardDefinition]:
+	if _reward_pool.is_empty() or count <= 0:
+		return []
+
+	var available_rewards: Array[RewardDefinition] = _reward_pool.duplicate()
+	available_rewards.shuffle()
+
+	var picked_rewards: Array[RewardDefinition] = []
+	var pick_count: int = min(count, available_rewards.size())
+	for i in range(pick_count):
+		picked_rewards.append(available_rewards[i])
+
+	return picked_rewards
+
+func apply_reward(reward: RewardDefinition, game_state: Node) -> void:
+	if reward == null or game_state == null:
+		return
+
+	match reward.type:
+		RewardDefinition.RewardType.ADD_HAND:
+			game_state.hands_remaining += int(reward.value)
+		RewardDefinition.RewardType.ADD_REROLL:
+			game_state.rerolls_remaining += int(reward.value)
+		RewardDefinition.RewardType.ADD_SCORE:
+			game_state.apply_score_to_quota(int(reward.value))
+		RewardDefinition.RewardType.SCORE_MULT:
+			game_state.round_score_multiplier += reward.value
+
+	if game_state.has_method("_emit_round_state"):
+		game_state.call("_emit_round_state")
+
+func _build_default_reward_pool() -> void:
+	_reward_pool.clear()
+	_reward_pool.append(_create_reward(
+		"add_hand",
+		"Tactical Reserve",
+		"+1 hand this round.",
+		RewardDefinition.RewardType.ADD_HAND,
+		1.0
+	))
+	_reward_pool.append(_create_reward(
+		"add_reroll",
+		"Lucky Shift",
+		"+1 reroll this round.",
+		RewardDefinition.RewardType.ADD_REROLL,
+		1.0
+	))
+	_reward_pool.append(_create_reward(
+		"add_score",
+		"Quota Relief",
+		"Reduce current quota by 50 immediately.",
+		RewardDefinition.RewardType.ADD_SCORE,
+		50.0
+	))
+	_reward_pool.append(_create_reward(
+		"score_mult",
+		"Momentum",
+		"+10% score multiplier for this round.",
+		RewardDefinition.RewardType.SCORE_MULT,
+		0.1
+	))
+
+func _create_reward(reward_id: String, reward_title: String, reward_description: String, reward_type: RewardDefinition.RewardType, reward_value: float) -> RewardDefinition:
+	var reward: RewardDefinition = RewardDefinition.new()
+	reward.id = reward_id
+	reward.title = reward_title
+	reward.description = reward_description
+	reward.type = reward_type
+	reward.value = reward_value
+	return reward

--- a/features/shop/reward_shop.gd
+++ b/features/shop/reward_shop.gd
@@ -1,0 +1,25 @@
+extends Control
+
+signal reward_selected(reward: RewardDefinition)
+
+@onready var rewards_container: VBoxContainer = $VBoxContainer
+
+func show_rewards(rewards: Array) -> void:
+	for child in rewards_container.get_children():
+		child.queue_free()
+
+	for reward_data in rewards:
+		var reward: RewardDefinition = reward_data
+		if reward == null:
+			continue
+
+		var button := Button.new()
+		button.text = "%s\n%s" % [reward.title, reward.description]
+		button.custom_minimum_size = Vector2(0, 72)
+		button.pressed.connect(_on_reward_pressed.bind(reward))
+		rewards_container.add_child(button)
+
+	visible = true
+
+func _on_reward_pressed(reward: RewardDefinition) -> void:
+	reward_selected.emit(reward)

--- a/features/shop/reward_shop.tscn
+++ b/features/shop/reward_shop.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://features/shop/reward_shop.gd" id="1_h8c6r"]
+
+[node name="RewardShop" type="Control"]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -220.0
+offset_top = -160.0
+offset_right = 220.0
+offset_bottom = 160.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_h8c6r")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 8

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -8,23 +8,27 @@ extends Control
 @onready var hand_type_value_label: Label = $VBoxContainer/HandTypeValue
 @onready var hands_left_leabel: Label = $VBoxContainer/HandaLeft
 @onready var rolls_left_label: Label = $VBoxContainer/RollsLeft
+@onready var reward_shop: Control = $RewardShop
 
 var score_manager: ScoreManager
+var reward_service: RewardService
 
 func _ready() -> void:
 	score_manager = ScoreManager.new()
 	add_child(score_manager)
+	reward_service = RewardService.new()
 
 	hand.played_hand_ready.connect(_on_played_hand_ready)
 	GameState.round_started.connect(_on_round_started)
 	GameState.round_completed.connect(_on_round_completed)
+	GameState.reward_phase_started.connect(_on_reward_phase_started)
 	GameState.run_failed.connect(_on_run_failed)
 	GameState.round_state_changed.connect(_on_round_state_changed)
 	EventBus.roll_all_dice_requested.connect(_on_roll_all_dice_requested)
+	reward_shop.reward_selected.connect(_on_reward_selected)
 
 	_refresh_hand_preview()
 	ui_update()
-	
 
 func _on_played_hand_ready(hand_data: DiceHand) -> void:
 	score_manager.preview_hand(hand_data.to_array())
@@ -51,13 +55,23 @@ func _get_played_hand_name() -> String:
 
 func _on_round_started(round_index: int, quota: int, hands: int, rerolls: int) -> void:
 	print("Round %d started | quota=%d hands=%d rerolls=%d" % [round_index, quota, hands, rerolls])
+	reward_shop.visible = false
 
 func _on_round_completed(round_index: int) -> void:
 	print("Round %d complete" % round_index)
+
+func _on_reward_phase_started() -> void:
+	var rewards := reward_service.generate_rewards(3)
+	reward_shop.show_rewards(rewards)
+
+func _on_reward_selected(reward: RewardDefinition) -> void:
+	reward_service.apply_reward(reward, GameState)
+	reward_shop.visible = false
 	GameState.start_next_round()
 
 func _on_run_failed(round_index: int) -> void:
 	print("Run failed on round %d" % round_index)
+	reward_shop.visible = false
 	GameState.start_new_run()
 
 func _on_round_state_changed(state: Dictionary) -> void:
@@ -67,7 +81,6 @@ func _on_round_state_changed(state: Dictionary) -> void:
 func _on_roll_all_dice_requested() -> void:
 	_refresh_hand_preview()
 	ui_update()
-
 
 func _refresh_hand_preview() -> void:
 	if hand == null or score_manager == null:
@@ -90,7 +103,7 @@ func ui_update(state: Dictionary = {}) -> void:
 	var hand_name := str(breakdown.get("hand_name", "-"))
 	var type_total := int(breakdown.get("type_total", 0))
 	var final_score := int(breakdown.get("final_score", 0))
-	
+
 	round_index_label.text = "Round %d" % state.get("round_index", 0)
 	quota_label.text = "Quota: %d" % int(state.get("quota_remaining", 0))
 	current_hand_points_label.text = "Current Hand Points: %d" % final_score

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://xsuucb46yeha" path="res://scenes/main.gd" id="1_0wfyh"]
 [ext_resource type="PackedScene" uid="uid://jf2sov4k6y2t" path="res://features/dice/hand/hand.tscn" id="2_0wfyh"]
 [ext_resource type="Shader" uid="uid://64giuyue21qd" path="res://assets/shaders/hex_background.gdshader" id="2_sugp2"]
+[ext_resource type="PackedScene" path="res://features/shop/reward_shop.tscn" id="4_qh0eg"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_jyhfs"]
 shader = ExtResource("2_sugp2")
@@ -80,3 +81,7 @@ text = "Hands Left"
 [node name="RollsLeft" type="Label" parent="VBoxContainer" unique_id=164711947]
 layout_mode = 2
 text = "Rolls Left"
+
+[node name="RewardShop" parent="." instance=ExtResource("4_qh0eg")]
+layout_mode = 0
+


### PR DESCRIPTION
### Motivation
- Introduce a reward phase at the end of a completed round to provide players with choices that affect the next round or remaining state.
- Support rewards that modify hands, rerolls, quota, or temporarily boost scoring via a per-round score multiplier.
- Centralize reward definitions and application logic so new reward types can be added safely and exposed to UI.

### Description
- Added `reward_phase_started` signal and `round_score_multiplier` to `autoload/game_state.gd`, reset multiplier at round start, include it in `get_round_state()`, and emit the reward phase when a round completes.
- Updated `core/node_classes/score_manager.gd` to apply `GameState.round_score_multiplier` when committing a played hand score.
- Added `core/resources/reward_definition.gd` as a `RewardDefinition` resource describing reward types and values.
- Implemented `core/services/reward_service.gd` to build a default reward pool, `generate_rewards(count)`, and `apply_reward(reward, game_state)` which modifies `hands_remaining`, `rerolls_remaining`, `quota` (via `apply_score_to_quota`), or `round_score_multiplier` and triggers `_emit_round_state` on the game state.
- Created a simple UI `features/shop/reward_shop.gd` and its scene `features/shop/reward_shop.tscn` to display selectable reward buttons and emit `reward_selected` when chosen.
- Integrated the reward flow into `scenes/main.gd` by instantiating `RewardService`, wiring `GameState.reward_phase_started` to show rewards, handling `reward_selected` to apply rewards, and toggling the reward shop visibility; also updated `scenes/main.tscn` to include the reward shop instance.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0195a0608331b37872c5f3d98ba6)