### PR TITLE
Fix Variant inference warning in RewardService

### DIFF
--- a/core/services/reward_service.gd
+++ b/core/services/reward_service.gd
@@ -14,7 +14,7 @@ func generate_rewards(count: int) -> Array[RewardDefinition]:
 	available_rewards.shuffle()
 
 	var picked_rewards: Array[RewardDefinition] = []
-	var pick_count := min(count, available_rewards.size())
+	var pick_count: int = mini(count, available_rewards.size())
 	for i in range(pick_count):
 		picked_rewards.append(available_rewards[i])
 


### PR DESCRIPTION
### Motivation
- Avoid a GDScript Variant type inference warning (treated as an error) by ensuring the reward pick count is an explicit integer.

### Description
- Replace `var pick_count := min(count, available_rewards.size())` with `var pick_count: int = mini(count, available_rewards.size())` in `core/services/reward_service.gd` to force an `int` result.

### Testing
- Searched the workspace for the pattern `var\s+\w+\s*:=\s*min\(` using `rg` and inspected `core/services/reward_service.gd` with `nl` to confirm the new line; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0a4cf5888331a4c296886e346288)