### PR TITLE
Apply shop rewards as next-round bonuses

### DIFF
--- a/autoload/game_state.gd
+++ b/autoload/game_state.gd
@@ -24,12 +24,17 @@ var quota_remaining: int = 0
 var hands_remaining: int = 0
 var rerolls_remaining: int = 0
 var round_score_multiplier: float = 1.0
+var _next_round_hands_bonus: int = 0
+var _next_round_rerolls_bonus: int = 0
+var _next_round_quota_reduction: int = 0
+var _next_round_score_multiplier_bonus: float = 0.0
 
 func _ready() -> void:
 	start_new_run()
 
 func start_new_run() -> void:
 	round_index = 1
+	_clear_pending_reward_bonuses()
 	run_started.emit(round_index)
 	start_round(round_index)
 
@@ -38,12 +43,25 @@ func start_next_round() -> void:
 	start_round(round_index)
 
 func start_round(target_round: int) -> void:
-	quota_remaining = _calculate_quota(target_round)
-	hands_remaining = _calculate_hands(target_round)
-	rerolls_remaining = BASE_REROLLS_PER_ROUND
-	round_score_multiplier = 1.0
+	quota_remaining = max(_calculate_quota(target_round) - _next_round_quota_reduction, 0)
+	hands_remaining = _calculate_hands(target_round) + _next_round_hands_bonus
+	rerolls_remaining = BASE_REROLLS_PER_ROUND + _next_round_rerolls_bonus
+	round_score_multiplier = 1.0 + _next_round_score_multiplier_bonus
+	_clear_pending_reward_bonuses()
 	round_started.emit(target_round, quota_remaining, hands_remaining, rerolls_remaining)
 	_emit_round_state()
+
+func add_next_round_hands_bonus(amount: int) -> void:
+	_next_round_hands_bonus += max(amount, 0)
+
+func add_next_round_rerolls_bonus(amount: int) -> void:
+	_next_round_rerolls_bonus += max(amount, 0)
+
+func add_next_round_quota_reduction(amount: int) -> void:
+	_next_round_quota_reduction += max(amount, 0)
+
+func add_next_round_score_multiplier_bonus(amount: float) -> void:
+	_next_round_score_multiplier_bonus += max(amount, 0.0)
 
 func consume_reroll() -> bool:
 	if rerolls_remaining <= 0:
@@ -93,3 +111,9 @@ func _evaluate_round_outcome() -> void:
 
 	if hands_remaining <= 0:
 		run_failed.emit(round_index)
+
+func _clear_pending_reward_bonuses() -> void:
+	_next_round_hands_bonus = 0
+	_next_round_rerolls_bonus = 0
+	_next_round_quota_reduction = 0
+	_next_round_score_multiplier_bonus = 0.0

--- a/core/services/reward_service.gd
+++ b/core/services/reward_service.gd
@@ -26,44 +26,45 @@ func apply_reward(reward: RewardDefinition, game_state: Node) -> void:
 
 	match reward.type:
 		RewardDefinition.RewardType.ADD_HAND:
-			game_state.hands_remaining += int(reward.value)
+			if game_state.has_method("add_next_round_hands_bonus"):
+				game_state.call("add_next_round_hands_bonus", int(reward.value))
 		RewardDefinition.RewardType.ADD_REROLL:
-			game_state.rerolls_remaining += int(reward.value)
+			if game_state.has_method("add_next_round_rerolls_bonus"):
+				game_state.call("add_next_round_rerolls_bonus", int(reward.value))
 		RewardDefinition.RewardType.ADD_SCORE:
-			game_state.apply_score_to_quota(int(reward.value))
+			if game_state.has_method("add_next_round_quota_reduction"):
+				game_state.call("add_next_round_quota_reduction", int(reward.value))
 		RewardDefinition.RewardType.SCORE_MULT:
-			game_state.round_score_multiplier += reward.value
-
-	if game_state.has_method("_emit_round_state"):
-		game_state.call("_emit_round_state")
+			if game_state.has_method("add_next_round_score_multiplier_bonus"):
+				game_state.call("add_next_round_score_multiplier_bonus", reward.value)
 
 func _build_default_reward_pool() -> void:
 	_reward_pool.clear()
 	_reward_pool.append(_create_reward(
 		"add_hand",
 		"Tactical Reserve",
-		"+1 hand this round.",
+		"+1 hand next round.",
 		RewardDefinition.RewardType.ADD_HAND,
 		1.0
 	))
 	_reward_pool.append(_create_reward(
 		"add_reroll",
 		"Lucky Shift",
-		"+1 reroll this round.",
+		"+1 reroll next round.",
 		RewardDefinition.RewardType.ADD_REROLL,
 		1.0
 	))
 	_reward_pool.append(_create_reward(
 		"add_score",
 		"Quota Relief",
-		"Reduce current quota by 50 immediately.",
+		"Reduce next round quota by 50.",
 		RewardDefinition.RewardType.ADD_SCORE,
 		50.0
 	))
 	_reward_pool.append(_create_reward(
 		"score_mult",
 		"Momentum",
-		"+10% score multiplier for this round.",
+		"+10% score multiplier next round.",
 		RewardDefinition.RewardType.SCORE_MULT,
 		0.1
 	))


### PR DESCRIPTION
### Motivation
- Shop reward selections were mutating the just-finished round state immediately, so upgrades did not take effect in the next round as intended. 
- Rewards are chosen during the between-round reward phase and therefore should be queued and applied during the next round initialization.

### Description
- Added pending bonus fields to `GameState`: `_next_round_hands_bonus`, `_next_round_rerolls_bonus`, `_next_round_quota_reduction`, and `_next_round_score_multiplier_bonus`.
- Implemented helper methods on `GameState` (`add_next_round_hands_bonus`, `add_next_round_rerolls_bonus`, `add_next_round_quota_reduction`, `add_next_round_score_multiplier_bonus`) plus `_clear_pending_reward_bonuses()` and consume the pending bonuses in `start_round()` and on `start_new_run()`.
- Updated `RewardService.apply_reward()` to call the `GameState` next-round helper methods instead of mutating current-round fields, and updated reward descriptions to state they affect the next round (e.g. `+1 hand next round.`).

### Testing
- Verified code changes via `git diff` and manual inspection of `autoload/game_state.gd` and `core/services/reward_service.gd` which show the pending-bonus fields and new method calls, and staged/committed the changes (`git status --short` and `git commit` succeeded).
- Attempted to run runtime verification with `godot --version` but Godot is not installed in this environment, so no engine-run tests were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad1050894483319ef2f6d1b714d988)