### PR TITLE
Split die/hand responsibilities into DieLogic and HandScoringSelector nodes

### DIFF
--- a/features/dice/die/die.tscn
+++ b/features/dice/die/die.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://55rde0afeujc" path="res://features/dice/die/die_ui.gd" id="1_clpct"]
 [ext_resource type="Theme" uid="uid://uigveapmlifl" path="res://assets/UI/style_boxes/die_theme.tres" id="1_os8ub"]
 [ext_resource type="Script" uid="uid://cynddjhf8ac5m" path="res://features/dice/die/die_animator.gd" id="2_b27w3"]
+[ext_resource type="Script" path="res://features/dice/die/die_logic.gd" id="3_logic"]
 [ext_resource type="Texture2D" uid="uid://d3yt4s6o26qdu" path="res://assets/sprites/Die.png" id="4_giyrb"]
 [ext_resource type="Texture2D" uid="uid://ca5hsdmvgqcdn" path="res://assets/sprites/Face Values.png" id="5_7lnrr"]
 
@@ -63,6 +64,9 @@ animator = NodePath("../AnimationPlayer")
 die = NodePath("..")
 die_face_sprite = NodePath("../DieFace")
 die_material_sprite = NodePath("../DieMaterial")
+
+[node name="DieLogic" type="Node" parent="." unique_id=111781122]
+script = ExtResource("3_logic")
 
 [node name="DieMaterial" type="Sprite2D" parent="." unique_id=1668521514]
 texture_filter = 1

--- a/features/dice/die/die_logic.gd
+++ b/features/dice/die/die_logic.gd
@@ -1,0 +1,30 @@
+extends Node
+class_name DieLogic
+
+signal die_rolled(face: FaceData)
+signal die_selected(selected: bool)
+
+var die: DieInstance
+var is_selected: bool = false
+
+func set_die(new_die: DieInstance) -> void:
+	die = new_die
+
+func roll_if_not_selected() -> FaceData:
+	if is_selected:
+		return null
+
+	if die == null:
+		push_error("DieLogic has no DieInstance assigned.")
+		return null
+
+	var roll_face := die.roll()
+	if roll_face == null:
+		return null
+
+	die_rolled.emit(roll_face)
+	return roll_face
+
+func toggle_selected() -> void:
+	is_selected = !is_selected
+	die_selected.emit(is_selected)

--- a/features/dice/die/die_ui.gd
+++ b/features/dice/die/die_ui.gd
@@ -1,52 +1,49 @@
 extends Control
 ## Visual/controller wrapper for a single [DieInstance].
-##
-## Responsibilities:
-## - hold/select state for reroll behavior
-## - show the current face value in UI
-## - expose a safe roll entry point for scene scripts
 class_name DieUI
 
-## Emitted when a roll happens from this UI control.
-## [param face] is the rolled face.
 signal die_rolled(face: FaceData)
-## Emitted when die is pressed and returns [param is_selected] is function.
 signal die_selected(selected: bool)
 
-## Runtime die backing this control.
-var die: DieInstance
-## If true, the die is "held" and should not roll.
-var is_selected: bool = false
+@onready var die_logic: DieLogic = $DieLogic
 
-## Assigns the die used by this UI.
-## If the die already has a current face, the label is immediately updated.
+var die: DieInstance:
+	get:
+		return die_logic.die
+	set(value):
+		die_logic.set_die(value)
+
+var is_selected: bool:
+	get:
+		return die_logic.is_selected
+	set(value):
+		die_logic.is_selected = value
+
+func _ready() -> void:
+	if not die_logic.die_rolled.is_connected(_on_logic_die_rolled):
+		die_logic.die_rolled.connect(_on_logic_die_rolled)
+	if not die_logic.die_selected.is_connected(_on_logic_die_selected):
+		die_logic.die_selected.connect(_on_logic_die_selected)
+
 func set_die(new_die: DieInstance) -> void:
-	die = new_die
-	if die.current_face != null:
+	die_logic.set_die(new_die)
+	if die != null and die.current_face != null:
 		$DieFace.frame = die.current_face.value - 1
 
-
-## Rolls only when this die is not selected/held.
-##
-## Returns:
-## - [FaceData] when a roll succeeds
-## - `null` when held, unassigned, or die config is invalid
 func roll_if_not_selected() -> FaceData:
-	if is_selected:
-		return null
-
-	if die == null:
-		push_error("DieUI has no DieInstance assigned.")
-		return null
-
-	var roll_face := die.roll()
+	var roll_face := die_logic.roll_if_not_selected()
 	if roll_face == null:
 		return null
-		
+
+	$DieFace.frame = roll_face.value - 1
 	$DieVisuals.play_roll_animation()
-	die_rolled.emit(roll_face)
 	return roll_face
 
 func _on_pressed() -> void:
-	is_selected = !is_selected
-	die_selected.emit(self)
+	die_logic.toggle_selected()
+
+func _on_logic_die_rolled(face: FaceData) -> void:
+	die_rolled.emit(face)
+
+func _on_logic_die_selected(selected: bool) -> void:
+	die_selected.emit(selected)

--- a/features/dice/hand/hand.gd
+++ b/features/dice/hand/hand.gd
@@ -2,13 +2,13 @@ extends Control
 
 @onready var hand_container = $HBoxContainer/Panel/HandContainer
 @onready var hand_animator: Node = $HandAnimator
+@onready var hand_scoring_selector: HandScoringSelector = $HandScoringSelector
 @export var die_ui_scene: PackedScene
 @export var dice_per_hand: int = 5
 @export var play_button: Button
 @export var roll_button: Button
 
 var is_hand_ready: bool = false
-var hand_evaluator := HandEvaluatorService.new()
 
 signal setup_complete
 signal played_hand_ready(hand: DiceHand)
@@ -61,66 +61,13 @@ func _on_play_pressed() -> void:
 		is_hand_ready = true
 		return
 
-	await animator.play_hand(_get_scoring_dice())
+	await animator.play_hand(hand_scoring_selector.get_scoring_dice(dice))
 	for die in dice:
 		die.is_selected = false
-	played_hand_ready.emit(_build_dice_hand())
-
-func _get_scoring_dice() -> Array[DieUI]:
-	if dice.is_empty():
-		return []
-
-	var values: Array[int] = []
-	for die: DieUI in dice:
-		if die.die == null or die.die.current_face == null:
-			continue
-		values.append(die.die.current_face.value)
-
-	if values.size() != dice.size():
-		return dice.duplicate()
-
-	var details := hand_evaluator.get_hand_details(values)
-	if details == null or details.groups.is_empty():
-		return dice.duplicate()
-
-	var counts_needed := _get_counts_needed(details)
-	if counts_needed.is_empty():
-		return dice.duplicate()
-
-	var scoring_dice: Array[DieUI] = []
-	for die: DieUI in dice:
-		if die.die == null or die.die.current_face == null:
-			continue
-		var value := die.die.current_face.value
-		var remaining := int(counts_needed.get(value, 0))
-		if remaining > 0:
-			scoring_dice.append(die)
-			counts_needed[value] = remaining - 1
-
-	if scoring_dice.is_empty():
-		return dice.duplicate()
-
-	return scoring_dice
-
-func _get_counts_needed(details: HandDetails) -> Dictionary:
-	var counts_needed := {}
-	for group_data in details.groups:
-		for group_name in group_data.keys():
-			var group_values: Array = group_data[group_name]
-			for value in group_values:
-				counts_needed[value] = int(counts_needed.get(value, 0)) + 1
-	return counts_needed
-
-
-func _build_dice_hand() -> DiceHand:
-	var values: Array[int] = []
-	for die_ui in dice:
-		if die_ui.die != null and die_ui.die.current_face != null:
-			values.append(die_ui.die.current_face.value)
-	return DiceHand.new(values)
+	played_hand_ready.emit(hand_scoring_selector.build_dice_hand(dice))
 
 func get_current_hand() -> DiceHand:
-	return _build_dice_hand()
+	return hand_scoring_selector.build_dice_hand(dice)
 
 func _on_played_hand_finish() -> void:
 	played_hand_finished.emit()

--- a/features/dice/hand/hand.tscn
+++ b/features/dice/hand/hand.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://biptkm4ujpe6i" path="res://features/dice/die/die.tscn" id="2_pxmyb"]
 [ext_resource type="Script" uid="uid://dqvho5iajwwdb" path="res://features/dice/hand/hand_animator.gd" id="3_7n5xe"]
 [ext_resource type="Theme" uid="uid://uigveapmlifl" path="res://assets/UI/style_boxes/die_theme.tres" id="3_oslr0"]
+[ext_resource type="Script" path="res://features/dice/hand/hand_scoring_selector.gd" id="4_selector"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7n5xe"]
 
@@ -31,6 +32,9 @@ roll_button = NodePath("HBoxContainer/ButtonContainer/roll")
 
 [node name="HandAnimator" type="Node" parent="." unique_id=308743313]
 script = ExtResource("3_7n5xe")
+
+[node name="HandScoringSelector" type="Node" parent="." unique_id=309901144]
+script = ExtResource("4_selector")
 
 [node name="HBoxContainer" type="VBoxContainer" parent="." unique_id=2047717781]
 layout_mode = 2

--- a/features/dice/hand/hand_scoring_selector.gd
+++ b/features/dice/hand/hand_scoring_selector.gd
@@ -1,0 +1,56 @@
+extends Node
+class_name HandScoringSelector
+
+var hand_evaluator := HandEvaluatorService.new()
+
+func get_scoring_dice(dice: Array[DieUI]) -> Array[DieUI]:
+	if dice.is_empty():
+		return []
+
+	var values: Array[int] = []
+	for die: DieUI in dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		values.append(die.die.current_face.value)
+
+	if values.size() != dice.size():
+		return dice.duplicate()
+
+	var details := hand_evaluator.get_hand_details(values)
+	if details == null or details.groups.is_empty():
+		return dice.duplicate()
+
+	var counts_needed := _get_counts_needed(details)
+	if counts_needed.is_empty():
+		return dice.duplicate()
+
+	var scoring_dice: Array[DieUI] = []
+	for die: DieUI in dice:
+		if die.die == null or die.die.current_face == null:
+			continue
+		var value := die.die.current_face.value
+		var remaining := int(counts_needed.get(value, 0))
+		if remaining > 0:
+			scoring_dice.append(die)
+			counts_needed[value] = remaining - 1
+
+	if scoring_dice.is_empty():
+		return dice.duplicate()
+
+	return scoring_dice
+
+func build_dice_hand(dice: Array[DieUI]) -> DiceHand:
+	var values: Array[int] = []
+	for die_ui in dice:
+		if die_ui.die != null and die_ui.die.current_face != null:
+			values.append(die_ui.die.current_face.value)
+	return DiceHand.new(values)
+
+func _get_counts_needed(details: HandDetails) -> Dictionary:
+	var counts_needed := {}
+	for group_data in details.groups:
+		for group_name in group_data.keys():
+			var group_values: Array = group_data[group_name]
+			for value in group_values:
+				counts_needed[value] = int(counts_needed.get(value, 0)) + 1
+	return counts_needed


### PR DESCRIPTION
### Motivation
- Reduce clutter in scene scripts by separating gameplay state/selection logic from UI and orchestration code.
- Make die behavior and hand scoring responsibilities easier to reason about, test, and reuse by moving them into focused helper nodes.

### Description
- Added a new `DieLogic` node script that owns die state, roll gating, hold toggling, and emits `die_rolled`/`die_selected` signals (`features/dice/die/die_logic.gd`).
- Refactored `DieUI` to delegate gameplay behavior to `DieLogic`, keep visual/frame updates in the UI, and re-emit logic signals (`features/dice/die/die_ui.gd`).
- Added a `HandScoringSelector` node script to encapsulate scoring-dice selection and `DiceHand` construction using the hand evaluator (`features/dice/hand/hand_scoring_selector.gd`).
- Updated the die and hand scenes to include the new nodes and wired the `Hand` script to call `HandScoringSelector` for scoring selection and hand building (`features/dice/die/die.tscn`, `features/dice/hand/hand.tscn`), and simplified `hand.gd` to orchestrate while delegating selection/building (`features/dice/hand/hand.gd`).

### Testing
- Attempted to run `godot --headless --check-only project.godot` to validate scenes, but `godot` is not installed in this environment so the check could not be performed (failure).
- Project-level automated tests or engine checks were not available; no further automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebe26d3448331889b4662a003d301)