### PR TITLE
Refactor hand-finish timing and reward bonus dispatch

### DIFF
--- a/core/services/reward_service.gd
+++ b/core/services/reward_service.gd
@@ -26,17 +26,17 @@ func apply_reward(reward: RewardDefinition, game_state: Node) -> void:
 
 	match reward.type:
 		RewardDefinition.RewardType.ADD_HAND:
-			if game_state.has_method("add_next_round_hands_bonus"):
-				game_state.call("add_next_round_hands_bonus", int(reward.value))
+			_apply_game_state_bonus(game_state, "add_next_round_hands_bonus", int(reward.value))
 		RewardDefinition.RewardType.ADD_REROLL:
-			if game_state.has_method("add_next_round_rerolls_bonus"):
-				game_state.call("add_next_round_rerolls_bonus", int(reward.value))
+			_apply_game_state_bonus(game_state, "add_next_round_rerolls_bonus", int(reward.value))
 		RewardDefinition.RewardType.ADD_SCORE:
-			if game_state.has_method("add_next_round_quota_reduction"):
-				game_state.call("add_next_round_quota_reduction", int(reward.value))
+			_apply_game_state_bonus(game_state, "add_next_round_quota_reduction", int(reward.value))
 		RewardDefinition.RewardType.SCORE_MULT:
-			if game_state.has_method("add_next_round_score_multiplier_bonus"):
-				game_state.call("add_next_round_score_multiplier_bonus", reward.value)
+			_apply_game_state_bonus(game_state, "add_next_round_score_multiplier_bonus", reward.value)
+
+func _apply_game_state_bonus(game_state: Node, method_name: StringName, amount: Variant) -> void:
+	if game_state.has_method(method_name):
+		game_state.call(method_name, amount)
 
 func _build_default_reward_pool() -> void:
 	_reward_pool.clear()

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -6,9 +6,11 @@ extends Control
 @onready var current_hand_points_label: Label = $VBoxContainer/CurrentHandPoints
 @onready var hand_type_label: Label = $VBoxContainer/HandType
 @onready var hand_type_value_label: Label = $VBoxContainer/HandTypeValue
-@onready var hands_left_leabel: Label = $VBoxContainer/HandaLeft
+@onready var hands_left_label: Label = $VBoxContainer/HandaLeft
 @onready var rolls_left_label: Label = $VBoxContainer/RollsLeft
 @onready var reward_shop: Control = $RewardShop
+
+const HAND_FINISH_DELAY_SECONDS: float = 1.0
 
 var score_manager: ScoreManager
 var reward_service: RewardService
@@ -35,8 +37,7 @@ func _on_played_hand_ready(hand_data: DiceHand) -> void:
 
 	if not score_manager.can_play_hand():
 		GameState.consume_hand()
-		await get_tree().create_timer(1).timeout
-		hand._on_played_hand_finish()
+		await _finish_hand_after_delay()
 		return
 
 	score_manager.play_hand()
@@ -46,8 +47,7 @@ func _on_played_hand_ready(hand_data: DiceHand) -> void:
 	GameState.apply_score_to_quota(applied_score)
 	GameState.consume_hand()
 
-	await get_tree().create_timer(1).timeout
-	hand._on_played_hand_finish()
+	await _finish_hand_after_delay()
 
 func _get_played_hand_name() -> String:
 	var breakdown := score_manager.get_last_breakdown()
@@ -95,6 +95,10 @@ func _refresh_hand_preview() -> void:
 
 	score_manager.preview_hand(current_hand.to_array())
 
+func _finish_hand_after_delay() -> void:
+	await get_tree().create_timer(HAND_FINISH_DELAY_SECONDS).timeout
+	hand._on_played_hand_finish()
+
 func ui_update(state: Dictionary = {}) -> void:
 	if state.is_empty():
 		state = GameState.get_round_state()
@@ -109,5 +113,5 @@ func ui_update(state: Dictionary = {}) -> void:
 	current_hand_points_label.text = "Current Hand Points: %d" % final_score
 	hand_type_label.text = "Hand Type: %s" % hand_name
 	hand_type_value_label.text = "Hand Type Value: %d" % type_total
-	hands_left_leabel.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))
+	hands_left_label.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))
 	rolls_left_label.text = "Rolls Left: %d" % int(state.get("rerolls_remaining", 0))


### PR DESCRIPTION
### Motivation
- Fix a UI variable naming typo for clarity and to avoid confusion when referencing labels in the main scene script.
- Centralize duplicated hand-finalization timing so the delay value and logic are easy to tune and less error-prone.
- Reduce duplication in reward application by consolidating GameState bonus dispatch into a single helper path.

### Description
- Renamed `hands_left_leabel` to `hands_left_label` in `scenes/main.gd` to correct the typo and updated all usages.
- Introduced `HAND_FINISH_DELAY_SECONDS` and extracted duplicated `create_timer` usage into `_finish_hand_after_delay()` in `scenes/main.gd`, and replaced the two inline timers with calls to the new helper.
- Simplified `RewardService.apply_reward()` in `core/services/reward_service.gd` by routing all GameState bonus calls through a new `_apply_game_state_bonus(game_state, method_name, amount)` helper to remove repeated `has_method`/`call` patterns.

### Testing
- Ran `git diff --check` which passed with no whitespace or diff-check issues.
- Verified repository status with `git status --short` and committed the changes successfully.
- Attempted to validate runtime behavior, but the Godot executable was not available in this environment so scene/runtime validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2abed9c388331bcd0d90acc1cb7d3)