### PR TITLE
Refactor score handling into score_bar script

### DIFF
--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,21 +1,12 @@
 extends Control
 
 @onready var hand: Node = $MarginContainer/Hand
-@onready var round_index_label: Label = $VBoxContainer/RoundIndex
-@onready var quota_label: Label = $VBoxContainer/Quota
-@onready var current_hand_points_label: Label = $VBoxContainer/CurrentHandPoints
-@onready var hand_type_label: Label = $VBoxContainer/HandType
-@onready var hand_type_value_label: Label = $VBoxContainer/HandTypeValue
-@onready var hands_left_leabel: Label = $VBoxContainer/HandaLeft
-@onready var rolls_left_label: Label = $VBoxContainer/RollsLeft
+@onready var score_bar: VBoxContainer = $VBoxContainer
 @onready var reward_shop: Control = $RewardShop
 
-var score_manager: ScoreManager
 var reward_service: RewardService
 
 func _ready() -> void:
-	score_manager = ScoreManager.new()
-	add_child(score_manager)
 	reward_service = RewardService.new()
 
 	hand.played_hand_ready.connect(_on_played_hand_ready)
@@ -28,30 +19,24 @@ func _ready() -> void:
 	reward_shop.reward_selected.connect(_on_reward_selected)
 
 	_refresh_hand_preview()
-	ui_update()
+	score_bar.update_state()
 
 func _on_played_hand_ready(hand_data: DiceHand) -> void:
-	score_manager.preview_hand(hand_data.to_array())
+	score_bar.preview_hand(hand_data)
 
-	if not score_manager.can_play_hand():
+	if not score_bar.can_play_previewed_hand():
 		GameState.consume_hand()
 		await get_tree().create_timer(1).timeout
 		hand._on_played_hand_finish()
 		return
 
-	score_manager.play_hand()
-	var played_hand_name := _get_played_hand_name()
-	var applied_score := score_manager.commit_played_hand()
-	print("Played hand: %s | points=%d" % [played_hand_name, applied_score])
-	GameState.apply_score_to_quota(applied_score)
+	var play_result := score_bar.play_previewed_hand()
+	print("Played hand: %s | points=%d" % [play_result.get("hand_name", "Unknown"), int(play_result.get("applied_score", 0))])
+	GameState.apply_score_to_quota(int(play_result.get("applied_score", 0)))
 	GameState.consume_hand()
 
 	await get_tree().create_timer(1).timeout
 	hand._on_played_hand_finish()
-
-func _get_played_hand_name() -> String:
-	var breakdown := score_manager.get_last_breakdown()
-	return str(breakdown.get("hand_name", "Unknown"))
 
 func _on_round_started(round_index: int, quota: int, hands: int, rerolls: int) -> void:
 	print("Round %d started | quota=%d hands=%d rerolls=%d" % [round_index, quota, hands, rerolls])
@@ -76,38 +61,18 @@ func _on_run_failed(round_index: int) -> void:
 
 func _on_round_state_changed(state: Dictionary) -> void:
 	print("State: ", state)
-	ui_update(state)
+	score_bar.update_state(state)
 
 func _on_roll_all_dice_requested() -> void:
 	_refresh_hand_preview()
-	ui_update()
+	score_bar.update_state()
 
 func _refresh_hand_preview() -> void:
-	if hand == null or score_manager == null:
+	if hand == null:
 		return
 
 	if not hand.has_method("get_current_hand"):
 		return
 
 	var current_hand: DiceHand = hand.call("get_current_hand")
-	if current_hand == null:
-		return
-
-	score_manager.preview_hand(current_hand.to_array())
-
-func ui_update(state: Dictionary = {}) -> void:
-	if state.is_empty():
-		state = GameState.get_round_state()
-
-	var breakdown := score_manager.get_last_breakdown()
-	var hand_name := str(breakdown.get("hand_name", "-"))
-	var type_total := int(breakdown.get("type_total", 0))
-	var final_score := int(breakdown.get("final_score", 0))
-
-	round_index_label.text = "Round %d" % state.get("round_index", 0)
-	quota_label.text = "Quota: %d" % int(state.get("quota_remaining", 0))
-	current_hand_points_label.text = "Current Hand Points: %d" % final_score
-	hand_type_label.text = "Hand Type: %s" % hand_name
-	hand_type_value_label.text = "Hand Type Value: %d" % type_total
-	hands_left_leabel.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))
-	rolls_left_label.text = "Rolls Left: %d" % int(state.get("rerolls_remaining", 0))
+	score_bar.preview_hand(current_hand)

--- a/scenes/score_bar.gd
+++ b/scenes/score_bar.gd
@@ -1,1 +1,71 @@
 extends VBoxContainer
+
+@onready var round_index_label: Label = $RoundIndex
+@onready var quota_label: Label = $Quota
+@onready var current_hand_points_label: Label = $CurrentHandPoints
+@onready var hand_type_label: Label = $HandType
+@onready var hand_type_value_label: Label = $HandTypeValue
+@onready var hands_left_leabel: Label = $HandaLeft
+@onready var rolls_left_label: Label = $RollsLeft
+
+var score_manager: ScoreManager
+
+func _ready() -> void:
+	score_manager = ScoreManager.new()
+	add_child(score_manager)
+
+
+func preview_hand(hand_data: DiceHand) -> void:
+	if hand_data == null or score_manager == null:
+		return
+
+	score_manager.preview_hand(hand_data.to_array())
+
+
+func can_play_previewed_hand() -> bool:
+	return score_manager != null and score_manager.can_play_hand()
+
+
+func play_previewed_hand() -> Dictionary:
+	if score_manager == null or not score_manager.can_play_hand():
+		return {
+			"played": false,
+			"hand_name": "Unknown",
+			"applied_score": 0,
+		}
+
+	score_manager.play_hand()
+	var played_hand_name := _get_played_hand_name()
+	var applied_score := score_manager.commit_played_hand()
+
+	return {
+		"played": true,
+		"hand_name": played_hand_name,
+		"applied_score": applied_score,
+	}
+
+
+func update_state(state: Dictionary = {}) -> void:
+	if score_manager == null:
+		return
+
+	if state.is_empty():
+		state = GameState.get_round_state()
+
+	var breakdown := score_manager.get_last_breakdown()
+	var hand_name := str(breakdown.get("hand_name", "-"))
+	var type_total := int(breakdown.get("type_total", 0))
+	var final_score := int(breakdown.get("final_score", 0))
+
+	round_index_label.text = "Round %d" % state.get("round_index", 0)
+	quota_label.text = "Quota: %d" % int(state.get("quota_remaining", 0))
+	current_hand_points_label.text = "Current Hand Points: %d" % final_score
+	hand_type_label.text = "Hand Type: %s" % hand_name
+	hand_type_value_label.text = "Hand Type Value: %d" % type_total
+	hands_left_leabel.text = "Hands Left: %d" % int(state.get("hands_remaining", 0))
+	rolls_left_label.text = "Rolls Left: %d" % int(state.get("rerolls_remaining", 0))
+
+
+func _get_played_hand_name() -> String:
+	var breakdown := score_manager.get_last_breakdown()
+	return str(breakdown.get("hand_name", "Unknown"))


### PR DESCRIPTION
### Motivation

- Reduce responsibility of the `main` scene by moving score-related UI state and score management into the score bar so the main controller focuses on round and reward orchestration.
- Encapsulate preview/play/commit score logic inside the score bar to make interactions with the `ScoreManager` localized and testable.

### Description

- Moved `ScoreManager` ownership and initialization from `scenes/main.gd` into `scenes/score_bar.gd` and added a `_ready` instantiation there.
- Added score-bar-level API methods in `scenes/score_bar.gd`: `preview_hand`, `can_play_previewed_hand`, `play_previewed_hand` (returns a dictionary with `played`, `hand_name`, and `applied_score`), and `update_state` which updates the labels.
- Updated `scenes/main.gd` to delegate score actions to the score bar by calling `score_bar.preview_hand`, `score_bar.can_play_previewed_hand`, `score_bar.play_previewed_hand`, and `score_bar.update_state`, and removed inline score UI management from `main`.
- Kept UI layout intact while moving label updates and score breakdown reads into `score_bar.gd` and implemented `_get_played_hand_name` helper there.

### Testing

- Attempted to run an engine sanity check with `godot --headless --check-only --path .`, but the `godot` binary is not available in this environment so the check could not be executed (failed).
- No automated in-repo unit tests were executed as part of this change due to the environment limitation above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b56bc26c833188932aa5c6fea131)