### PR TITLE
Persist shop item lock across rerolls and visits

### DIFF
--- a/autoload/game_state.gd
+++ b/autoload/game_state.gd
@@ -69,6 +69,7 @@ var general_modifiers: Dictionary:
 
 var _player_manager: GameStatePlayerManager = GameStatePlayerManager.new()
 var _run_manager: GameStateRunManager = GameStateRunManager.new()
+var _locked_shop_offers: Array[Dictionary] = []
 
 func _ready() -> void:
 	start_new_run()
@@ -78,6 +79,7 @@ func start_new_run() -> void:
 	_player_manager.clear_hand_type_upgrades()
 	_player_manager.clear_shop_items()
 	_player_manager.reset_general_modifiers()
+	clear_locked_shop_offers()
 	initialize_player_hand(BASE_DICE_PER_HAND, BASE_DIE_FACE_COUNT)
 	currency_changed.emit(currency)
 	general_modifiers_changed.emit(get_general_modifiers())
@@ -232,3 +234,12 @@ func _emit_round_state() -> void:
 
 func get_run_stats() -> Dictionary:
 	return _run_manager.get_run_stats()
+
+func set_locked_shop_offers(offers: Array[Dictionary]) -> void:
+	_locked_shop_offers = offers.duplicate(true)
+
+func get_locked_shop_offers() -> Array[Dictionary]:
+	return _locked_shop_offers.duplicate(true)
+
+func clear_locked_shop_offers() -> void:
+	_locked_shop_offers.clear()

--- a/docs/architecture/event_flow.md
+++ b/docs/architecture/event_flow.md
@@ -51,6 +51,15 @@ Round cleared in GameState
 -> Scene changes to shop
 ```
 
+```text
+Shop lock toggle changed
+-> ItemButton emits lock_toggled(is_locked)
+-> ShopView re-emits offer_lock_toggled(index, is_locked)
+-> ShopController updates locked offer snapshots in GameState
+-> Shop reroll keeps locked offers and only re-rolls remaining slots
+-> Returning to shop restores locked offers from GameState snapshots
+```
+
 ---
 
 ## 2. Signal-by-signal flow
@@ -103,6 +112,16 @@ Round cleared in GameState
 | 3 | `GameState` | `reward_phase_started` | `MainRoundFlowController.handle_reward_phase_started()` | Upgrade UI is refreshed and shown. |
 | 4 | `HandTypeUpgradesView` | `upgrade_selected(upgrade)` | `MainRoundFlowController.handle_upgrade_selected()` | Upgrade is applied and shop scene is opened. |
 | 5 | `HandTypeUpgradesView` | `reroll_requested` | `MainRoundFlowController.handle_upgrade_reroll_requested()` | Replacement upgrades are generated. |
+
+### E. Shop lock flow
+
+| Step | Emitter | Signal | Receiver | Next action |
+| --- | --- | --- | --- | --- |
+| 1 | `ItemButton` | `lock_toggled(is_locked)` | `ShopView._on_offer_lock_toggled()` | Converts button-local lock state into offer-index intent. |
+| 2 | `ShopView` | `offer_lock_toggled(index, is_locked)` | `ShopController._on_offer_lock_toggled()` | Stores/removes locked-offer snapshot by shop tracking key. |
+| 3 | `ShopController` | direct call `GameState.set_locked_shop_offers(entries)` | `GameState` | Persists locked-offer snapshots for later shop visits in the same run. |
+| 4 | Shop reroll button | `reroll_requested` | `ShopController._on_reroll_requested()` | Re-rolls only unlocked slots and keeps locked offers in the next render. |
+| 5 | Shop scene `_ready()` | controller restore call | `ShopController._restore_locked_offers()` | Rehydrates locked offers and rebuilds the mixed (locked + rolled) offer list. |
 
 ---
 

--- a/features/ItemButton/item_button.gd
+++ b/features/ItemButton/item_button.gd
@@ -1,10 +1,17 @@
 extends Button
 
+signal lock_toggled(is_locked: bool)
+
 @export var title_label: Label
 @export var discription_label: Label
 @export var price_label: Label
 @export var rarity_label: Label
 @export var texture_rect: TextureRect
+@export var lock_button: CheckButton
+
+func _ready() -> void:
+	if lock_button != null:
+		lock_button.toggled.connect(_on_lock_toggled)
 
 func set_title(title: String):
 	title_label.text = title
@@ -29,8 +36,21 @@ func set_border_color(new_color: Color):
 	self_modulate = new_color
 	rarity_label.modulate = new_color
 
+func set_locked(is_locked: bool) -> void:
+	if lock_button == null:
+		return
+	lock_button.set_pressed_no_signal(is_locked)
+
+func is_locked() -> bool:
+	if lock_button == null:
+		return false
+	return lock_button.button_pressed
+
 func _on_mouse_entered() -> void:
 	z_index = 1
 
 func _on_mouse_exited() -> void:
 	z_index = 0
+
+func _on_lock_toggled(is_locked: bool) -> void:
+	lock_toggled.emit(is_locked)

--- a/features/ItemButton/item_button.tscn
+++ b/features/ItemButton/item_button.tscn
@@ -25,7 +25,7 @@ region = Rect2(0, 16, 16, 16)
 font = ExtResource("3_l2xpd")
 font_size = 32
 
-[node name="TrinketButton" type="Button" unique_id=678501366 node_paths=PackedStringArray("title_label", "discription_label", "price_label", "rarity_label", "texture_rect")]
+[node name="TrinketButton" type="Button" unique_id=678501366 node_paths=PackedStringArray("title_label", "discription_label", "price_label", "rarity_label", "texture_rect", "lock_button")]
 custom_minimum_size = Vector2(300, 400)
 offset_right = 300.0
 offset_bottom = 400.0
@@ -41,6 +41,7 @@ discription_label = NodePath("MarginContainer/VBoxContainer/Discription")
 price_label = NodePath("MarginContainer/VBoxContainer/HBoxContainer/Price")
 rarity_label = NodePath("MarginContainer/VBoxContainer/Header/VBoxContainer/Rarity")
 texture_rect = NodePath("MarginContainer/VBoxContainer/Header/TextureRect")
+lock_button = NodePath("Lock")
 
 [node name="Hover animation" parent="." unique_id=251388993 instance=ExtResource("4_l82o7")]
 

--- a/scenes/shop/controllers/shop_controller.gd
+++ b/scenes/shop/controllers/shop_controller.gd
@@ -18,6 +18,7 @@ var _offer_service: ShopOfferService = ShopOfferService.new()
 var _purchase_service: ShopPurchaseService = ShopPurchaseService.new()
 var _transaction_port: ShopTransactionPort
 var _shop_rerolls_purchased: int = 0
+var _locked_offer_snapshots: Dictionary = {}
 
 func _ready() -> void:
 	if shop_view == null:
@@ -28,12 +29,14 @@ func _ready() -> void:
 	_apply_balance_config()
 	_transaction_port = GameStateShopTransactionPort.new(GameState)
 	shop_view.offer_purchase_requested.connect(_on_offer_purchase_requested)
+	shop_view.offer_lock_toggled.connect(_on_offer_lock_toggled)
 	shop_view.reroll_requested.connect(_on_reroll_requested)
 	shop_view.continue_requested.connect(_on_continue_requested)
 	GameState.currency_changed.connect(_on_currency_changed)
 	GameState.general_modifiers_changed.connect(_on_general_modifiers_changed)
 
 	shop_view.set_roll_cost(_get_scaled_shop_reroll_cost())
+	_restore_locked_offers()
 	_roll_offers()
 	_refresh_view()
 
@@ -45,8 +48,10 @@ func _on_offer_purchase_requested(index: int) -> void:
 	if not _purchase_service.apply_purchase(_transaction_port, offer):
 		return
 
+	_remove_locked_offer(offer)
 	_offers.remove_at(index)
-	shop_view.set_offers(_offers, GameState.currency)
+	_persist_locked_offers()
+	shop_view.set_offers(_offers, GameState.currency, _get_locked_offer_keys())
 	_refresh_view()
 
 func _on_reroll_requested() -> void:
@@ -86,20 +91,46 @@ func _on_currency_changed(_amount: int) -> void:
 func _on_general_modifiers_changed(_modifiers: Dictionary) -> void:
 	_refresh_view()
 
+func _on_offer_lock_toggled(index: int, is_locked: bool) -> void:
+	if index < 0 or index >= _offers.size():
+		return
+	var offer := _offers[index]
+	if offer == null:
+		return
+	if is_locked:
+		_track_locked_offer(offer)
+	else:
+		_remove_locked_offer(offer)
+	_persist_locked_offers()
+
 func _roll_offers() -> void:
+	var locked_offers := _get_locked_offer_list()
+	var remaining_slots := maxi(_get_offer_count() - locked_offers.size(), 0)
+	var locked_offer_keys := _get_locked_offer_keys()
+	var candidate_pool: Array[TrinketData] = []
+	for trinket: TrinketData in trinket_pool:
+		if trinket == null:
+			continue
+		if locked_offer_keys.has(trinket.get_shop_tracking_key()):
+			continue
+		candidate_pool.append(trinket)
 	var rolled_offers := _offer_service.roll_weighted_offers(
-		trinket_pool,
+		candidate_pool,
 		max(GameState.round_index, 1),
-		_get_offer_count(),
+		remaining_slots,
 		true,
 		GameState.get_shop_item_counts()
 	)
 	_offers.clear()
+	for locked_offer: TrinketData in locked_offers:
+		if locked_offer == null:
+			continue
+		_offers.append(locked_offer)
 	for offer: TrinketData in rolled_offers:
 		if offer == null:
 			continue
 		_offers.append(_build_round_scaled_offer(offer))
-	shop_view.set_offers(_offers, GameState.currency)
+	shop_view.set_offers(_offers, GameState.currency, locked_offer_keys)
 
 func _refresh_view() -> void:
 	if shop_view == null:
@@ -111,6 +142,68 @@ func _refresh_view() -> void:
 	shop_view.set_reroll_enabled(_purchase_service.can_afford_purchase(GameState.currency, reroll_cost))
 	shop_view.refresh_offer_affordability(GameState.currency)
 	shop_view.set_inventory_entries(_build_inventory_entries(GameState.get_owned_trinkets()))
+
+func _track_locked_offer(offer: TrinketData) -> void:
+	if offer == null:
+		return
+	var key := offer.get_shop_tracking_key()
+	var snapshot := {
+		"key": key,
+		"cost": offer.cost,
+	}
+	_locked_offer_snapshots[key] = snapshot
+
+func _remove_locked_offer(offer: TrinketData) -> void:
+	if offer == null:
+		return
+	_locked_offer_snapshots.erase(offer.get_shop_tracking_key())
+
+func _persist_locked_offers() -> void:
+	var entries: Array[Dictionary] = []
+	for snapshot: Dictionary in _locked_offer_snapshots.values():
+		entries.append(snapshot.duplicate(true))
+	GameState.set_locked_shop_offers(entries)
+
+func _restore_locked_offers() -> void:
+	_locked_offer_snapshots.clear()
+	for entry: Dictionary in GameState.get_locked_shop_offers():
+		var key := str(entry.get("key", ""))
+		if key.is_empty():
+			continue
+		_locked_offer_snapshots[key] = {
+			"key": key,
+			"cost": int(entry.get("cost", -1)),
+		}
+
+func _get_locked_offer_keys() -> Dictionary:
+	var keys: Dictionary = {}
+	for key: Variant in _locked_offer_snapshots.keys():
+		keys[key] = true
+	return keys
+
+func _get_locked_offer_list() -> Array[TrinketData]:
+	var locked_offers: Array[TrinketData] = []
+	for snapshot: Dictionary in _locked_offer_snapshots.values():
+		var key := str(snapshot.get("key", ""))
+		if key.is_empty():
+			continue
+		var offer := _build_offer_from_key(key, int(snapshot.get("cost", -1)))
+		if offer == null:
+			continue
+		locked_offers.append(offer)
+	return locked_offers
+
+func _build_offer_from_key(key: String, cost_override: int = -1) -> TrinketData:
+	for trinket: TrinketData in trinket_pool:
+		if trinket == null:
+			continue
+		if trinket.get_shop_tracking_key() != key:
+			continue
+		var offer := _build_round_scaled_offer(trinket)
+		if cost_override >= 0:
+			offer.cost = cost_override
+		return offer
+	return null
 
 func _build_round_scaled_offer(source_offer: TrinketData) -> TrinketData:
 	var priced_offer := source_offer.duplicate(true) as TrinketData

--- a/scenes/shop/shop.gd
+++ b/scenes/shop/shop.gd
@@ -3,6 +3,7 @@ extends Control
 class_name ShopView
 
 signal offer_purchase_requested(index: int)
+signal offer_lock_toggled(index: int, is_locked: bool)
 signal reroll_requested
 signal continue_requested
 
@@ -16,6 +17,7 @@ signal continue_requested
 
 var _offers: Array[TrinketData] = []
 var _offer_buttons: Array[Button] = []
+var _locked_offer_keys: Dictionary = {}
 
 func _ready() -> void:
 	if reroll_button:
@@ -35,8 +37,9 @@ func set_round_display(round_index: int, max_rounds: int) -> void:
 	if currency_label:
 		currency_label.set_round(round_index, max_rounds)
 
-func set_offers(offers: Array[TrinketData], currency_amount: int) -> void:
+func set_offers(offers: Array[TrinketData], currency_amount: int, locked_offer_keys: Dictionary = {}) -> void:
 	_offers = offers.duplicate()
+	_locked_offer_keys = locked_offer_keys.duplicate(true)
 	_rebuild_offer_buttons(currency_amount)
 
 func set_inventory_entries(entries: Array[Dictionary]) -> void:
@@ -106,6 +109,11 @@ func _rebuild_offer_buttons(currency_amount: int) -> void:
 		button.set_texture(offer.get_texture())
 		button.set_border_color(offer.get_rarity_color())
 		button.pressed.connect(_on_offer_button_pressed.bind(i))
+		if button.has_method("set_locked"):
+			var offer_key := offer.get_shop_tracking_key()
+			button.set_locked(bool(_locked_offer_keys.get(offer_key, false)))
+		if button.has_signal("lock_toggled"):
+			button.lock_toggled.connect(_on_offer_lock_toggled.bind(i))
 		button.tooltip_text = "%s\nCost: %d marbles" % [offer.get_display_name(), offer.cost]
 		offers_container.add_child(button)
 		_offer_buttons.append(button)
@@ -114,6 +122,9 @@ func _rebuild_offer_buttons(currency_amount: int) -> void:
 
 func _on_offer_button_pressed(index: int) -> void:
 	offer_purchase_requested.emit(index)
+
+func _on_offer_lock_toggled(is_locked: bool, index: int) -> void:
+	offer_lock_toggled.emit(index, is_locked)
 
 func _on_reroll_pressed() -> void:
 	reroll_requested.emit()


### PR DESCRIPTION
### Motivation
- Allow players to lock shop offers so selected items remain present across rerolls and when returning to the shop during the same run while keeping UI presentation logic free of game behavior.
- Follow the project event-driven rule by emitting UI signals and letting the controller/service layer manage persistence and reroll behavior.

### Description
- Add `lock_toggled(is_locked: bool)` signal, `lock_button` export, and `set_locked`/`is_locked` helpers to `ItemButton` so lock state is exposed without embedding game logic in the UI (`features/ItemButton/item_button.gd` and `.tscn`).
- Extend `ShopView` with `offer_lock_toggled(index, is_locked)` and a `locked_offer_keys` passthrough so the view re-emits lock intents and can render locked buttons without owning lock behaviour (`scenes/shop/shop.gd`).
- Implement lock snapshot tracking in `ShopController` that restores persisted locks on ready, persists lock snapshots into `GameState`, removes snapshots on purchase, and changes `_roll_offers()` to keep locked offers while re-rolling only unlocked slots (`scenes/shop/controllers/shop_controller.gd`).
- Add run-scoped locked-offer storage API to `GameState` with `set_locked_shop_offers`, `get_locked_shop_offers`, and `clear_locked_shop_offers()` which are cleared when a new run starts (`autoload/game_state.gd`).
- Document the new shop lock event flow in the event flow reference (`docs/architecture/event_flow.md`).

### Testing
- Ran `git diff --check` to validate the working tree and diff formatting, and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d83f0810833199338adfd854d005)